### PR TITLE
Protocol cleanup

### DIFF
--- a/src/types/string.rs
+++ b/src/types/string.rs
@@ -9,18 +9,21 @@ use types::VarInt;
 /// UTF-8 string prefixed with its length as a VarInt.
 impl Protocol for String {
     type Clean = String;
+
     fn proto_len(value: &String) -> usize {
         let str_len = value.len();
         <VarInt as Protocol>::proto_len(&(str_len as i32)) + str_len
     }
+
     fn proto_encode(value: String, dst: &mut Writer) -> IoResult<()> {
         let str_len = value.len() as i32;
         try!(<VarInt as Protocol>::proto_encode(str_len, dst));
         try!(dst.write_str(value.as_slice()));
         Ok(())
     }
-    fn proto_decode(src: &mut Reader, plen: usize) -> IoResult<String> {
-        let len: i32 = try!(<VarInt as Protocol>::proto_decode(src, plen));
+
+    fn proto_decode(src: &mut Reader) -> IoResult<String> {
+        let len: i32 = try!(<VarInt as Protocol>::proto_decode(src));
         let s = try!(src.read_exact(len as usize));
         let utf8s = try!(String::from_utf8(s).map_err(|utf8_err| IoError {
             kind: IoErrorKind::InvalidInput,

--- a/src/types/uuid.rs
+++ b/src/types/uuid.rs
@@ -1,40 +1,31 @@
 //! MC Protocol UUID data type.
 
-use std::old_io::{ IoError, IoErrorKind, IoResult, MemReader };
+use std::old_io::{ IoError, IoErrorKind, IoResult };
 
 use packet::Protocol;
 use uuid::Uuid;
 
-/// UUID read/write wrapper, two signed 64-bit integers.
+/// UUID read/write wrapper.
 impl Protocol for Uuid {
     type Clean = Uuid;
+
     #[allow(unused_variables)]
     fn proto_len(value: &Uuid) -> usize { 16 }
-    /// Writes `value` as two i64 into `dst`
+
+    /// Writes `value` into `dst`
     fn proto_encode(value: Uuid, dst: &mut Writer) -> IoResult<()> {
-        let mut mr = MemReader::new(value.as_bytes().to_vec());
-        let a = try!(mr.read_be_i64());
-        let b = try!(mr.read_be_i64());
-        try!(dst.write_be_i64(a));
-        try!(dst.write_be_i64(b));
-        Ok(())
+        dst.write_all(value.as_bytes())
     }
-    /// Reads two i64 (16 bytes) from `src` and returns an `Uuid`
+
+    /// Reads 16 bytes from `src` and returns a `Uuid`
     #[allow(unused_variables)]
-    fn proto_decode(src: &mut Reader, plen: usize) -> IoResult<Uuid> {
-        let a = try!(src.read_be_i64());
-        let b = try!(src.read_be_i64());
-        let mut v = Vec::new();
-        try!(v.write_be_i64(a));
-        try!(v.write_be_i64(b));
-        match Uuid::from_bytes(v.as_slice()) {
-            Some(u) => Ok(u),
-            None => Err(IoError {
-                kind: IoErrorKind::InvalidInput,
-                desc: "invalid UUID value",
-                detail: Some(format!("value {:?} can't be used to create UUID", v))
-            }),
-        }
+    fn proto_decode(src: &mut Reader) -> IoResult<Uuid> {
+        let v = try!(src.read_exact(16));
+        Uuid::from_bytes(&v).ok_or(IoError {
+            kind: IoErrorKind::InvalidInput,
+            desc: "invalid UUID value",
+            detail: Some(format!("value {:?} can't be used to create UUID", v))
+        })
     }
 }
 

--- a/src/types/varnum.rs
+++ b/src/types/varnum.rs
@@ -170,7 +170,7 @@ mod tests {
         let tests = varint_tests();
         for test in tests.iter() {
             let mut r = MemReader::new(test.bytes.clone());
-            let value = <VarInt as Protocol>::proto_decode(&mut r, 0).unwrap();
+            let value = <VarInt as Protocol>::proto_decode(&mut r).unwrap();
             assert_eq!(test.value, value);
         }
     }
@@ -190,7 +190,7 @@ mod tests {
         let tests = varlong_tests();
         for test in tests.iter() {
             let mut r = MemReader::new(test.bytes.clone());
-            let value = <VarLong as Protocol>::proto_decode(&mut r, 0).unwrap();
+            let value = <VarLong as Protocol>::proto_decode(&mut r).unwrap();
             assert_eq!(test.value, value);
         }
     }


### PR DESCRIPTION
-   Remove the `plen` argument from `proto_decode`. The `Protocol` trait doesn't suffice for packet decoding anyway.
-   Use loops in `VarInt::proto_len` and `VarLong::proto_len`, and error instead of panicking when decoding fails.
-   Don't split UUIDs into two `i64`s, encode/decode them directly instead.
