### PR TITLE
Refactor packets

### DIFF
--- a/src/packet.rs
+++ b/src/packet.rs
@@ -100,7 +100,7 @@ macro_rules! packets {
             pub mod $state_mod {
                 pub mod clientbound {
                     #![allow(unused_imports)]
-                    use packet::{Packet, Protocol};
+                    use packet::{Packet, Protocol, State};
                     use types::{Arr, Nbt, Slot, Var};
 
                     use std::io;
@@ -117,7 +117,7 @@ macro_rules! packets {
 
                 pub mod serverbound {
                     #![allow(unused_imports)]
-                    use packet::{Packet, Protocol};
+                    use packet::{Packet, Protocol, State};
                     use types::{Arr, Nbt, Slot, Var};
 
                     use std::io;
@@ -143,6 +143,7 @@ macro_rules! packets {
             $($state($state_mod::PacketEnum)),*
         }
         
+        #[derive(Debug)]
         pub enum State {
             $($state),*
         }
@@ -239,10 +240,71 @@ impl Protocol for bool {
     }
 }
 
+/// Optional values encoded as a bool-prefixed value.
+impl<T: Protocol> Protocol for Option<T> {
+    type Clean = Option<T::Clean>;
+
+    fn proto_len(value: &Option<T::Clean>) -> usize {
+        match *value {
+            Some(ref inner) => 1 + <T as Protocol>::proto_len(inner),
+            None => 1
+        }
+    }
+
+    fn proto_encode(value: &Option<T::Clean>, dst: &mut Write) -> io::Result<()> {
+        match *value {
+            Some(ref inner) => {
+                try!(<bool as Protocol>::proto_encode(&true, dst));
+                try!(<T as Protocol>::proto_encode(inner, dst));
+            }
+            None => {
+                try!(<bool as Protocol>::proto_encode(&false, dst));
+            }
+        }
+        Ok(())
+    }
+
+    fn proto_decode(src: &mut Read) -> io::Result<Option<T::Clean>> {
+        if try!(<bool as Protocol>::proto_decode(src)) {
+            Ok(Some(try!(<T as Protocol>::proto_decode(src))))
+        } else {
+            Ok(None)
+        }
+    }
+}
+
+/// Encodes the `State` based on the values in the `Handshake` packet.
+///
+/// Can only encode `Status` and `Login` states, others will result in an error.
+impl Protocol for State {
+    type Clean = State;
+
+    #[allow(unused_variables)]
+    fn proto_len(value: &State) -> usize { 1 }
+
+    fn proto_encode(value: &State, dst: &mut Write) -> io::Result<()> {
+        let i = match *value {
+            State::Status => 1,
+            State::Login => 2,
+            _ => return Err(io::Error::new(io::ErrorKind::InvalidInput, "invalid state", None))
+        };
+        try!(<Var<i32> as Protocol>::proto_encode(&i, dst));
+        Ok(())
+    }
+
+    fn proto_decode(src: &mut Read) -> io::Result<State> {
+        match try!(<Var<i32> as Protocol>::proto_decode(src)) {
+            1 => Ok(State::Status),
+            2 => Ok(State::Login),
+            _ => Err(io::Error::new(io::ErrorKind::InvalidInput, "invalid state", None))
+        }
+    }
+}
+
 packets! {
     Handshaking => handshake {
         clientbound {
-            0x00 => Handshake { proto_version: Var<i32>, server_address: String, server_port: u16, next_state: Var<i32> }
+            0x00 => Handshake { proto_version: Var<i32>, server_address: String, server_port: u16, next_state: State }
         }
         serverbound {}
     }
@@ -253,7 +315,7 @@ packets! {
             // 0x02 => ChatMessage { data: Chat, position: i8 }
             0x03 => TimeUpdate { world_age: i64, time_of_day: i64 }
             0x04 => EntityEquipment { entity_id: Var<i32>, slot: i16, item: Option<Slot> }
-            0x05 => SpawnPosition { location: i64 }
+            0x05 => WorldSpawn { location: i64 }
             0x06 => UpdateHealth { health: f32, food: Var<i32>, saturation: f32 }
             0x07 => Respawn { dimension: i32, difficulty: u8, gamemode: u8, level_type: String }
             0x08 => PlayerPositionAndLook { x: f64, y: f64, z: f64, yaw: f32, pitch: f32, flags: i8 }
@@ -261,60 +323,60 @@ packets! {
             0x0a => UseBed { entity_id: Var<i32>, location: i64 }
             0x0b => Animation { entity_id: Var<i32>, animation: u8 }
             // 0x0c => SpawnPlayer { entity_id: Var<i32>, player_uuid: Uuid, x: i32, y: i32, z: i32, yaw: u8, pitch: u8, current_item: i16, metadata: Metadata }
-            0x0d => CollectItem { collected_entity_id: Var<i32>, collector_entity_id: Var<i32> }
+            0x0d => CollectItem { collected_eid: Var<i32>, collector_eid: Var<i32> }
             // 0x0e => SpawnObject { entity_id: Var<i32>, type_: i8, x: i32, y: i32, z: i32, pitch: u8, yaw: u8, data: ObjectData }
-            // 0x0f => SpawnMob { entity_id: Var<i32>, type_: u8, x: i32, y: i32, z: i32, yaw: u8, pitch: u8, velocity_x: i16, velocity_y: i16, velocity_z: i16, metadata: Metadata }
+            // 0x0f => SpawnMob { entity_id: Var<i32>, type_: u8, x: i32, y: i32, z: i32, yaw: u8, pitch: u8, head_pitch: u8, velocity_x: i16, velocity_y: i16, velocity_z: i16, metadata: Metadata }
             0x10 => SpawnPainting { entity_id: Var<i32>, title: String, location: i64, direction: u8 }
             0x11 => SpawnExperienceOrb { entity_id: Var<i32>, x: i32, y: i32, z: i32, count: i16 }
             0x12 => EntityVelocity { entity_id: Var<i32>, velocity_x: i16, velocity_y: i16, velocity_z: i16 }
             0x13 => DestroyEntities { entity_ids: Arr<Var<i32>, Var<i32>> }
-            0x14 => Entity { entity_id: Var<i32> }
+            0x14 => EntityIdle { entity_id: Var<i32> }
             0x15 => EntityRelativeMove { entity_id: Var<i32>, delta_x: i8, delta_y: i8, delta_z: i8, on_ground: bool }
             0x16 => EntityLook { entity_id: Var<i32>, yaw: u8, pitch: u8, on_ground: bool }
             0x17 => EntityLookAndRelativeMove { entity_id: Var<i32>, delta_x: i8, delta_y: i8, delta_z: i8, yaw: u8, pitch: u8, on_ground: bool }
             0x18 => EntityTeleport { entity_id: Var<i32>, x: i32, y: i32, z: i32, yaw: u8, pitch: u8, on_ground: bool }
             0x19 => EntityHeadLook { entity_id: Var<i32>, head_yaw: u8 }
             0x1A => EntityStatus { entity_id: i32, entity_status: i8 }
-            0x1B => AttachEntity { entity_id: i32, vehicle_id: i32, leash: bool }
+            0x1B => AttachEntity { riding_eid: i32, vehicle_eid: i32, leash: bool }
             // 0x1C => EntityMetadata { entity_id: Var<i32>, metadata: Metadata }
             0x1D => EntityEffect { entity_id: Var<i32>, effect_id: i8, amplifier: i8, duration: Var<i32>, hide_particles: bool }
             0x1E => RemoveEntityEffect { entity_id: Var<i32>, effect_id: i8 }
             0x1F => SetExperience { xp_bar: f32, level: Var<i32>, xp_total: Var<i32> }
             // 0x20 => EntityProperties { entity_id: Var<i32>, properties: Arr<i32, Property> }
-            // 0x21 => ChunkData { chunk_x: i32, chunk_z: i32, ground_up_continuous: bool, mask: u16, chunk_data: Chunk }
-            // 0x22 => MultiBlockChange { chunk_x: i32, chunk_z: i32, records: Arr<Var<i32>, Record> }
+            // 0x21 => ChunkData { chunk_x: i32, chunk_z: i32, ground_up_continuous: bool, mask: u16, chunk_data: Chunk; encode { ... }; decode { ... }; } // chunk_data is length-prefixed and may or may not represent an entire chunk column
+            // 0x22 => MultiBlockChange { chunk_x: i32, chunk_z: i32, records: Arr<Var<i32>, BlockChangeRecord> }
             0x23 => BlockChange { location: i64, block_id: Var<i32> }
             0x24 => BlockAction { location: i64, byte1: u8, byte2: u8, block_type: Var<i32> }
             0x25 => BlockBreakAnimation { entity_id: Var<i32>, location: i64, destroy_stage: i8 }
-            // 0x26 => MapChunkBulk { sky_light_sent: bool, chunks: Custom<Vec<Chunk>> } // PROBLEM: chunks is encoded as two arrays, the first one specifying which sections of each chunk column are empty
+            // 0x26 => MapChunkBulk { sky_light_sent: bool, chunks: Vec<Chunk>; encode { ... }; decode { ... }; } // PROBLEM: chunks is encoded as two arrays, the first one specifying which sections of each chunk column are empty
             // 0x27 => Explosion { x: f32, y: f32, z: f32, radius: f32, records: Arr<i32, ExplosionOffset>, player_motion_x: f32, player_motion_y: f32, player_motion_z: f32 }
             0x28 => Effect { effect_id: i32, location: i64, data: i32, disable_relative_volume: bool }
-            0x29 => SoundEffect { name: String, effect_x: i32, effect_y: i32, effect_z: i32, volume: f32, pitch: u8 }
-            // 0x2a => Particle { particle_id: i32, long_distance: bool, x: f32, y: f32, z: f32, offset_x: f32, offset_y: f32, offset_z: f32, particle_data: f32, data: Arr<i32, Var<i32>> }
+            0x29 => SoundEffect { name: String, x: i32, y: i32, z: i32, volume: f32, pitch: u8 }
+            // 0x2a => Particle { particle_id: i32, long_distance: bool, x: f32, y: f32, z: f32, offset_x: f32, offset_y: f32, offset_z: f32, particle_data: f32, particle_count: i32, data: Vec<i32>; encode { ... }; decode { ... }; } // PROBLEM: length of data depends on particle_id
             0x2b => ChangeGameState { reason: u8, value: f32 }
             0x2c => SpawnGlobalEntity { entity_id: Var<i32>, type_: i8, x: i32, y: i32, z: i32 }
-            // 0x2d => OpenWindow { window_id: u8, window_type: String, window_title: Chat, slots: u8, entity_id: Custom<Option<i32>> } // PROBLEM: entity_id depends on window_type
+            // 0x2d => OpenWindow { window_id: u8, window_type: String, window_title: Chat, slots: u8, entity_id: Option<i32>; encode { ... }; decode { ... }; } // PROBLEM: entity_id depends on window_type
             0x2e => CloseWindow { window_id: u8 }
             0x2f => SetSlot { window_id: u8, slot: i16, data: Option<Slot> }
             0x30 => WindowItems { window_id: u8, slots: Arr<i16, Option<Slot>> }
             0x31 => WindowProperty { window_id: u8, property: i16, value: i16 }
             0x32 => ConfirmTransaction { window_id: u8, action_number: i16, accepted: bool }
             // 0x33 => UpdateSign { location: i64, line0: Chat, line1: Chat, line2: Chat, line3: Chat }
-            // 0x34 => UpdateMap { item_damage: Var<i32>, scale: i8, icons: Arr<Var<i32>, MapIcon>, data: MapData } // MapData is a quirky format holding optional pixel data for an arbitrary rectangle on the map
-            // 0x35 => UpdateBlockEntity { location: i64, action: u8, nbt_data: Nbt } // PROBLEM: nbt_data is omitted entirely if it encodes an empty NBT tag
+            // 0x34 => UpdateMap { map_id: Var<i32>, scale: i8, icons: Arr<Var<i32>, MapIcon>, data: MapData } // MapData is a quirky format holding optional pixel data for an arbitrary rectangle on the map
+            // 0x35 => UpdateBlockEntity { location: i64, action: u8, nbt_data: Nbt; encode { ... }; decode { ... }; } // PROBLEM: nbt_data is omitted entirely if it encodes an empty NBT tag
             0x36 => SignEditorOpen { location: i64 }
             // 0x37 => Statistics { stats: Arr<Var<i32>, Stat> }
-            // 0x38 => PlayerListItem { action: Var<i32>, players: Arr<Var<i32>, PlayerListItem> }
+            // 0x38 => UpdatePlayerList { action: Var<i32>, players: Arr<Var<i32>, PlayerListItem> }
             0x39 => PlayerAbilities { flags: i8, flying_speed: f32, walking_speed: f32 }
             0x3a => TabComplete { matches: Arr<Var<i32>, String> }
-            // 0x3b => ScoreboardObjective { objective_name: String, mode: ScoreMode }
+            // 0x3b => ScoreboardObjective { objective_name: String, mode: ObjectiveAction }
             // 0x3c => UpdateScore { score_name: String, action: ScoreAction }
             0x3d => DisplayScoreboard { position: i8, score_name: String }
-            // 0x3e => Teams { team_name: String, team: TeamMode }
-            // 0x3f => PluginMessage { channel: String, data: Custom<Vec<u8>> } // PROBLEM: length of `data` comes from packet length
+            // 0x3e => UpdateTeam { team_name: String, action: TeamAction }
+            // 0x3f => PluginMessage { channel: String, data: Vec<u8>; encode { ... }; decode { ... }; } // PROBLEM: length of `data` comes from packet length
             // 0x40 => Disconnect { reason: Chat }
             0x41 => ServerDifficulty { difficulty: u8 }
-            // 0x42 => CombatEvent { event: CombatEvent }
+            // 0x42 => PlayCombatEvent { event: CombatEvent }
             0x43 => Camera { camera_id: Var<i32> }
             // 0x44 => WorldBorder { action: WorldBorderAction }
             // 0x45 => Title { action: TitleAction }
@@ -325,31 +387,31 @@ packets! {
         }
         serverbound {
             0x00 => KeepAlive { keep_alive_id: i32 }
-            0x01 => ChatMessage { message: String }
-            // 0x02 => UseEntity { target: i32, use_type: UseType }
-            0x03 => Player { on_ground: bool }
+            // 0x01 => ChatMessage { message: Chat }
+            // 0x02 => UseEntity { target_eid: i32, use_type: EntityUseAction }
+            0x03 => PlayerIdle { on_ground: bool }
             0x04 => PlayerPosition { x: f64, y: f64, z: f64, on_ground: bool }
             0x05 => PlayerLook { yaw: f32, pitch: f32, on_ground: bool }
             0x06 => PlayerPositionAndLook { x: f64, y: f64, z: f64, yaw: f32, pitch: f32, on_ground: bool }
             0x07 => PlayerDigging { status: i8, location: i64, face: i8 }
-            // 0x08 => PlayerBlockPlacement { location: i64, direction: i8, held_item: Nbt, cursor_x: i8, cursor_y: i8, cursor_z: i8 }
+            0x08 => PlayerBlockPlacement { location: i64, direction: i8, held_item: Option<Slot>, cursor_x: i8, cursor_y: i8, cursor_z: i8 }
             0x09 => HeldItemChange { slot: i16 }
             0x0a => Animation {}
-            0x0b => EntityAction { entity_id: i32, action_id: i32, jump_boost: i32 }
+            0x0b => EntityAction { entity_id: Var<i32>, action_id: Var<i32>, jump_boost: Var<i32> }
             0x0c => SteerVehicle { sideways: f32, forward: f32, flags: u8 }
-            0x0d => CloseWindow { window_id: i8 }
-            // 0x0e => ClickWindow { window_id: i8, slot: i16, button: i8, action_number: i16, mode: i8, clicked_item: Nbt }
-            0x0f => ConfirmTransaction { window_id: i8, action_number: i16, accepted: bool }
-            0x10 => CreativeInventoryAction { slot: i16, clicked_item: i16 }
-            0x11 => EnchantItem { window_id: i8, enchantment: i8 }
-            0x12 => UpdateSign { location: i64, line0: String, line1: String, line2: String, line3: String }
+            0x0d => CloseWindow { window_id: u8 }
+            0x0e => ClickWindow { window_id: u8, slot: i16, button: i8, action_number: i16, mode: i8, clicked_item: Option<Slot> }
+            0x0f => ConfirmTransaction { window_id: u8, action_number: i16, accepted: bool }
+            0x10 => CreativeInventoryAction { slot: i16, clicked_item: Option<Slot> }
+            0x11 => EnchantItem { window_id: u8, enchantment: i8 }
+            // 0x12 => UpdateSign { location: i64, line0: Chat, line1: Chat, line2: Chat, line3: Chat }
             0x13 => PlayerAbilities { flags: i8, flying_speed: f32, walking_speed: f32 }
-            // 0x14 => TabComplete { text: String, block_position: TabPosition }
+            0x14 => TabComplete { text: String, looking_at: Option<i64> }
             0x15 => ClientSettings { locale: String, view_distance: i8, chat_mode: i8, chat_colors: bool, displayed_skin_parts: u8 }
-            0x16 => ClientStatus { action_id: i32 }
-            // 0x17 => PluginMessage { channel: String, data: Vec<u8> }
+            0x16 => ClientStatus { action_id: Var<i32> }
+            // 0x17 => PluginMessage { channel: String, data: Vec<u8>; encode { ... }; decode { ... }; } // PROBLEM: length of `data` comes from packet length
             0x18 => Spectate { target_player: Uuid }
-            0x19 => ResourcePackStatus { hash: String, result: i32 }
+            0x19 => ResourcePackStatus { hash: String, result: Var<i32> }
         }
     }
     Status => status {
@@ -364,9 +426,9 @@ packets! {
     }
     Login => login {
         clientbound {
-            // 0x00 => LoginDisconnect { reason: Chat }
+            // 0x00 => Disconnect { reason: Chat }
             0x01 => EncryptionRequest { server_id: String, pubkey: Arr<Var<i32>, u8>, verify_token: Arr<Var<i32>, u8> }
-            0x02 => LoginSuccess { uuid: String, username: String } // NOTE(toqueteos): uuid field is not an Uuid!
+            // 0x02 => LoginSuccess { uuid: Uuid, username: String; encode { ... }; decode { ... }; } // NOTE: uuid field is encoded as a string!
             0x03 => SetCompression { threshold: Var<i32> }
         }
         serverbound {

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -6,16 +6,27 @@ use std::error::FromError;
 use std::io;
 use std::io::prelude::*;
 
-use types::VarInt;
+use types::Var;
 
-use uuid::Uuid;
-
+/// A trait used for data which can be encoded/decoded as is.
 pub trait Protocol {
     type Clean = Self;
 
     fn proto_len(value: &Self::Clean) -> usize;
     fn proto_encode(value: &Self::Clean, dst: &mut Write) -> io::Result<()>;
     fn proto_decode(src: &mut Read) -> io::Result<Self::Clean>;
+}
+
+/// A trait for encoding/decoding the body of a single packet type.
+pub trait Packet {
+    fn len(&self) -> usize;
+    fn encode(&self, dst: &mut Write) -> io::Result<()>;
+    fn decode(src: &mut Read, len: usize) -> io::Result<Self>;
+}
+
+pub enum Direction {
+    Clientbound,
+    Serverbound
 }
 
 macro_rules! packet {
@@ -26,29 +37,18 @@ macro_rules! packet {
             $(pub $fname: <$fty as Protocol>::Clean),*
         }
 
-        impl Protocol for $name {
-            type Clean = $name;
-            fn proto_len(value: &$name) -> usize {
-                0 $(+ <$fty as Protocol>::proto_len(&value.$fname) as usize)*
+        impl Packet for $name {
+            fn len(&self) -> usize {
+                0 $(+ <$fty as Protocol>::proto_len(&self.$fname) as usize)*
             }
 
-            fn proto_encode(value: &$name, mut dst: &mut Write) -> io::Result<()> {
-                let len = <VarInt as Protocol>::proto_len(&$id) + <$name as Protocol>::proto_len(value);
-                try!(<VarInt as Protocol>::proto_encode(&(len as i32), dst));
-                try!(<VarInt as Protocol>::proto_encode(&$id, dst));
-                $(try!(<$fty as Protocol>::proto_encode(&value.$fname, dst));)*
-                // println!("proto_encode name={} id={:x} length={}", stringify!($name), $id, len);
+            fn encode(&self, mut dst: &mut Write) -> io::Result<()> {
+                $(try!(<$fty as Protocol>::proto_encode(&self.$fname, dst));)*
                 Ok(())
             }
 
             #[allow(unused_variables)]
-            fn proto_decode(mut src: &mut Read) -> io::Result<$name> {
-                let len: i32 = try!(<VarInt as Protocol>::proto_decode(src));
-                let id: i32 = try!(<VarInt as Protocol>::proto_decode(src));
-                // println!("proto_decode name={} id={:x}", stringify!($name), id);
-                if id != $id {
-                    return Err(io::Error::new(io::ErrorKind::InvalidInput, "unexpected packet", Some(format!("Expected packet id #{:x}, got #{:x} instead.", $id, id))));
-                }
+            fn decode(mut src: &mut Read, len: usize) -> io::Result<$name> {
                 Ok($name {
                     $($fname: try!(<$fty as Protocol>::proto_decode(src))),*
                 })
@@ -60,38 +60,113 @@ macro_rules! packet {
         #[derive(Debug)]
         pub struct $name;
 
-        impl Protocol for $name {
-            type Clean = $name;
+        impl Packet for $name {
+            #[allow(unused_variables)]
+            fn len(&self) -> usize { 0 }
 
             #[allow(unused_variables)]
-            fn proto_len(value: &$name) -> usize { 0 }
-
-            fn proto_encode(value: &$name, dst: &mut Write) -> io::Result<()> {
-                let len = 1 + <$name as Protocol>::proto_len(value);
-                try!(<VarInt as Protocol>::proto_encode(&(len as i32), dst));
-                try!(<VarInt as Protocol>::proto_encode(&$id, dst));
-                // println!("proto_encode name={} id={:x} length={}", stringify!($name), $id, len);
+            fn encode(&self, dst: &mut Write) -> io::Result<()> {
                 Ok(())
             }
 
             #[allow(unused_variables)]
-            fn proto_decode(src: &mut Read) -> io::Result<$name> {
-                let len: i32 = try!(<VarInt as Protocol>::proto_decode(src));
-                let id: i32 = try!(<VarInt as Protocol>::proto_decode(src));
-                // println!("proto_decode name={} id={:x}", stringify!($name), id);
-                if id != $id {
-                    Err(io::Error::new(io::ErrorKind::InvalidInput, "unexpected packet", Some(format!("Expected packet id #{:x}, got #{:x} instead.", $id, id))))
-                } else {
-                    Ok($name)
-                }
+            fn decode(src: &mut Read, len: usize) -> io::Result<$name> {
+                Ok($name)
             }
+        }
+    };
+    // Custom encode/decode packets
+    ($name:ident ($id:expr) { $($fname:ident: $fty:ty),+; encode $encode:block; decode $decode:block; }) => {
+        pub struct $name {
+            $(pub $fname: $fty),*
+        }
+
+        impl Packet for $name {
+            fn len(&self) -> usize {
+                let mut buf = vec![];
+                self.encode(&mut buf);
+                buf.len()
+            }
+
+            fn encode(&self, mut dst: &mut Write) -> io::Result<()> $encode
+            fn decode(mut src: &mut Read, len: usize) -> io::Result<$name> $decode
         }
     }
 }
 
 macro_rules! packets {
-    ($($id:expr => $name:ident {$($packet:tt)*})*) => {
-        $(packet!{ $name ($id) { $($packet)* } })*
+    ($($state:ident => $state_mod:ident { clientbound { $($c_id:expr => $c_name:ident { $($c_packet:tt)* })* } serverbound { $($s_id:expr => $s_name:ident { $($s_packet:tt)* })* } })*) => {
+        $(
+            pub mod $state_mod {
+                pub mod clientbound {
+                    #![allow(unused_imports)]
+                    use packet::{Packet, Protocol};
+                    use types::{Arr, Nbt, Slot, Var};
+
+                    use std::io;
+                    use std::io::prelude::*;
+
+                    use uuid::Uuid;
+
+                    $(packet!{ $c_name ($c_id) { $($c_packet)* } })*
+
+                    pub enum PacketEnum {
+                        $($c_name($c_name)),*
+                    }
+                }
+
+                pub mod serverbound {
+                    #![allow(unused_imports)]
+                    use packet::{Packet, Protocol};
+                    use types::{Arr, Nbt, Slot, Var};
+
+                    use std::io;
+                    use std::io::prelude::*;
+
+                    use uuid::Uuid;
+
+                    $(packet!{ $s_name ($s_id) { $($s_packet)* } })*
+
+                    pub enum PacketEnum {
+                        $($s_name($s_name)),*
+                    }
+                }
+
+                pub enum PacketEnum {
+                    Clientbound(clientbound::PacketEnum),
+                    Serverbound(serverbound::PacketEnum)
+                }
+            }
+        )*
+
+        pub enum PacketEnum {
+            $($state($state_mod::PacketEnum)),*
+        }
+        
+        pub enum State {
+            $($state),*
+        }
+
+        /// Reads a new packet from a reader, wrapping in an enum for exhaustive matching.
+        ///
+        /// **TODO:** add support for compression.
+        fn read_packet(direction: Direction, state: State, mut src: &mut Read) -> io::Result<PacketEnum> {
+            let proto_len = try!(<Var<i32> as Protocol>::proto_decode(src));
+            let id = try!(<Var<i32> as Protocol>::proto_decode(src));
+            let len = proto_len as usize - <Var<i32> as Protocol>::proto_len(&id);
+            match state {
+                $(State::$state => match direction {
+                    Direction::Clientbound => match id {
+                        $($c_id => Ok(PacketEnum::$state($state_mod::PacketEnum::Clientbound($state_mod::clientbound::PacketEnum::$c_name(try!(<$state_mod::clientbound::$c_name as Packet>::decode(src, len)))))),)*
+                        _ => Err(io::Error::new(io::ErrorKind::InvalidInput, "unknown packet id for clientbound packet", None))
+                    },
+                    Direction::Serverbound => match id {
+                        $($s_id => Ok(PacketEnum::$state($state_mod::PacketEnum::Serverbound($state_mod::serverbound::PacketEnum::$s_name(try!(<$state_mod::serverbound::$s_name as Packet>::decode(src, len)))))),)*
+                        _ => Err(io::Error::new(io::ErrorKind::InvalidInput, "unknown packet id for serverbound packet", None))
+                    }
+                }),*
+            }
+        }
     }
 }
 
@@ -165,117 +240,138 @@ impl Protocol for bool {
 }
 
 packets! {
-    // Clientbound packets
-    0x00 => ClientKeepAlive                 { keep_alive_id: VarInt }
-    0x01 => ClientJoinGame                  { entity_id: i32, gamemode: u8, dimension: i8, difficulty: u8, max_players: u8, level_type: String, reduced_debug_info: bool }
-    // 0x02 => ClientChatMessage               { data: Chat, position: i8 }
-    0x03 => ClientTimeUpdate                { world_age: i64, time_of_day: i64 }
-    // 0x04 => ClientEntityEquipment           { entity_id: i32, slot: i16, item: Nbt }
-    0x05 => ClientSpawnPosition             { location: i64 }
-    0x06 => ClientUpdateHealth              { health: f32, food: i32, food_saturation: f32 }
-    0x07 => ClientRespawn                   { dimension: i32, difficulty: u8, gamemode: u8, level_type: String }
-    0x08 => ClientPlayerPositionAndLook     { x: f64, y: f64, z: f64, yaw: f32, pitch: f32, flags: i8 }
-    0x09 => ClientHeldItemChange            { slot: i8 }
-    0x0a => ClientUseBed                    { entity_id: i32, location: i64 }
-    0x0b => ClientAnimation                 { entity_id: i32, animation: u8 }
-    // 0x0c => ClientSpawnPlayer               { entity_id: i32, player_uuid: Uuid, x: i32, y: i32, z: i32, yaw: u8, pitch: u8, current_item: i16, metadata: Metadata }
-    0x0d => ClientCollectItem               { collected_entity_id: i32, collector_entity_id: i32 }
-    // 0x0e => ClientSpawnObject               { entity_id: i32, type_: i8, x: i32, y: i32, z: i32, pitch: u8, yaw: u8, data: ObjectData }
-    // 0x0f => ClientSpawnMob                  { entity_id: i32, type_: u8, x: i32, y: i32, z: i32, yaw: u8, pitch: u8, velocity_x: i16, velocity_y: i16, velocity_z: i16, metadata: Metadata }
-    0x10 => ClientSpawnPainting             { entity_id: i32, title: String, location: i64, direction: u8 }
-    0x11 => ClientSpawnExperienceOrb        { entity_id: i32, x: i32, y: i32, z: i32, count: i16 }
-    0x12 => ClientEntityVelocity            { entity_id: i32, velocity_x: i16, velocity_y: i16, velocity_z: i16 }
-    // 0x13 => ClientDestroyEntities           { entity_ids: Vec<VarInt> }
-    0x14 => ClientEntity                    { entity_id: i32 }
-    0x15 => ClientEntityRelativeMove        { entity_id: i32, delta_x: i8, delta_y: i8, delta_z: i8, on_ground: bool }
-    0x16 => ClientEntityLook                { entity_id: i32, yaw: u8, pitch: u8, on_ground: bool }
-    0x17 => ClientEntityLookAndRelativeMove { entity_id: i32, delta_x: i8, delta_y: i8, delta_z: i8, yaw: u8, pitch: u8, on_ground: bool }
-    0x18 => ClientEntityTeleport            { entity_id: i32, x: i32, y: i32, z: i32, yaw: u8, pitch: u8, on_ground: bool }
-    0x19 => ClientEntityHeadLook            { entity_id: i32, head_yaw: u8 }
-    0x1A => ClientEntityStatus              { entity_id: i32, entity_status: i8 }
-    0x1B => ClientAttachEntity              { entity_id: i32, vehicle_id: i32, leash: bool }
-    // 0x1C => ClientEntityMetadata            { entity_id: i32, metadata: Metadata }
-    0x1D => ClientEntityEffect              { entity_id: i32, effect_id: i8, amplifier: i8, duration: i32, hide_particles: bool }
-    0x1E => ClientRemoveEntityEffect        { entity_id: i32, effect_id: i8 }
-    0x1F => ClientSetExperience             { xp_bar: f32, level: i32, xp_total: i32 }
-    // 0x20 => ClientEntityProperties          { entity_id: i32, properties: Vec<Property> }
-    // 0x21 => ClientChunkData                 { chunk_x: i32, chunk_z: i32, ground_up_continuous: bool, mask: i16, chunk_data: Vec<Chunk> }
-    // 0x22 => ClientMultiBlockChange          { chunk_x: i32, chunk_z: i32, records: Vec<Record> }
-    0x23 => ClientBlockChange               { location: i64, block_id: i32 }
-    0x24 => ClientBlockAction               { location: i64, byte1: u8, byte2: u8, block_type: i32 }
-    0x25 => ClientBlockBreakAnimation       { entity_id: i32, location: i64, destroy_stage: i8 }
-    // 0x26 => ClientMapChunkBulk              { sky_light_sent: bool, chunks: Option<(Vec<ChunkMeta>, Vec<Chunk>)> }
-    // 0x27 => ClientExplosion                 { x: f32, y: f32, z: f32, radius: f32, records: Vec<ExplosionOffset>, player_motion_x: f32, player_motion_y: f32, player_motion_z: f32 }
-    0x28 => ClientEffect                    { effect_id: i32, location: i64, data: i32, disable_relative_volume: bool }
-    0x29 => ClientSoundEffect               { name: String, effect_x: i32, effect_y: i32, effect_z: i32, volume: f32, pitch: u8 }
-    // 0x2a => ClientParticle                  { particle_id: i32, long_distance: bool, x: f32, y: f32, z: f32, offset_x: f32, offset_y: f32, offset_z: f32, particle_data: f32, data: Vec<VarInt> }
-    0x2b => ClientChangeGameState           { reason: u8, value: f32 }
-    0x2c => ClientSpawnGlobalEntity         { entity_id: i32, type_: i8, x: i32, y: i32, z: i32 }
-    // 0x2d => ClientOpenWindow                { window_id: u8, window_type: String, window_title: Chat, slots: u8, entity_id: Option<i32> } // PROBLEM: entity_id depends on window_type
-    0x2e => ClientCloseWindow               { window_id: u8 }
-    // 0x2f => ClientSetSlot                   { window_id: u8, slot: i16, data: Slot }
-    // 0x30 => ClientWindowItems               { window_id: u8, slots: Vec<Slot> }
-    0x31 => ClientWindowProperty            { window_id: u8, property: i16, value: i16 }
-    0x32 => ClientConfirmTransaction        { window_id: u8, action_number: i16, accepted: bool }
-    0x33 => ClientUpdateSign                { location: i64, line0: String, line1: String, line2: String, line3: String }
-    // 0x34 => ClientMaps                      { item_damage: i32, scale: i8, icons: MapIcons, columns: MapColumns }
-    0x35 => ClientUpdateBlockEntity         { location: i64, action: u8, nbt_data: u8 }
-    0x36 => ClientSignEditorOpen            { location: i64 }
-    // 0x37 => ClientStatistics                { stats: Stats }
-    // 0x38 => ClientPlayerListItem            { action: i32, players: Players }
-    0x39 => ClientPlayerAbilities           { flags: i8, flying_speed: f32, walking_speed: f32 }
-    // 0x3a => ClientTabComplete               { matches: Matches }
-    // 0x3b => ClientScoreboardObjective       { objective_name: String, mode: ScoreMode }
-    // 0x3c => ClientUpdateScore               { score_name: String, action: ScoreAction }
-    0x3d => ClientDisplayScoreboard         { position: i8, score_name: String }
-    // 0x3e => ClientTeams                     { team_name: String, team: Team }
-    // 0x3f => ClientPluginMessage             { channel: String, data: Vec<u8> } // PROBLEM: length of `data` comes from packet length
-    // 0x40 => ClientDisconnect                { reason: Chat }
-    0x41 => ClientServerDifficulty          { difficulty: u8 }
-    // 0x42 => ClientCombatEvent               { event: Event }
-    0x43 => ClientCamera                    { camera_id: i32 }
-    // 0x44 => ClientWorldBorder               { action: WorldBorderAction }
-    // 0x45 => ClientTitle                     { action: TitleAction }
-    0x46 => ClientSetCompression            { threshold: VarInt }
-    // 0x47 => ClientPlayerListHeaderFooter    { header: Chat, footer: Chat }
-    0x48 => ClientResourcePackSend          { url: String, hash: String }
-    // 0x49 => ClientUpdateEntityNbt           { entity_id: i32, tag: Nbt }
-    // Serverbound packets
-    0x00 => ServerKeepAlive                 { keep_alive_id: i32 }
-    0x01 => ServerChatMessage               { message: String }
-    // 0x02 => ServerUseEntity                 { target: i32, use_type: UseType }
-    0x03 => ServerPlayer                    { on_ground: bool }
-    0x04 => ServerPlayerPosition            { x: f64, y: f64, z: f64, on_ground: bool }
-    0x05 => ServerPlayerLook                { yaw: f32, pitch: f32, on_ground: bool }
-    0x06 => ServerPlayerPositionAndLook     { x: f64, y: f64, z: f64, yaw: f32, pitch: f32, on_ground: bool }
-    0x07 => ServerPlayerDigging             { status: i8, location: i64, face: i8 }
-    // 0x08 => ServerPlayerBlockPlacement      { location: i64, direction: i8, held_item: Nbt, cursor_x: i8, cursor_y: i8, cursor_z: i8 }
-    0x09 => ServerHeldItemChange            { slot: i16 }
-    0x0a => ServerAnimation {}
-    0x0b => ServerEntityAction              { entity_id: i32, action_id: i32, jump_boost: i32 }
-    0x0c => ServerSteerVehicle              { sideways: f32, forward: f32, flags: u8 }
-    0x0d => ServerCloseWindow               { window_id: i8 }
-    // 0x0e => ServerClickWindow               { window_id: i8, slot: i16, button: i8, action_number: i16, mode: i8, clicked_item: Nbt }
-    0x0f => ServerConfirmTransaction        { window_id: i8, action_number: i16, accepted: bool }
-    0x10 => ServerCreativeInventoryAction   { slot: i16, clicked_item: i16 }
-    0x11 => ServerEnchantItem               { window_id: i8, enchantment: i8 }
-    0x12 => ServerUpdateSign                { location: i64, line0: String, line1: String, line2: String, line3: String }
-    0x13 => ServerPlayerAbilities           { flags: i8, flying_speed: f32, walking_speed: f32 }
-    // 0x14 => ServerTabComplete               { text: String, block_position: TabPosition }
-    0x15 => ServerClientSettings            { locale: String, view_distance: i8, chat_mode: i8, chat_colors: bool, displayed_skin_parts: u8 }
-    0x16 => ServerClientStatus              { action_id: i32 }
-    // 0x17 => ServerPluginMessage             { channel: String, data: Vec<u8> }
-    0x18 => ServerSpectate                  { target_player: Uuid }
-    0x19 => ServerResourcePackStatus        { hash: String, result: i32 }
-    // Handshake
-    0x00 => Handshake                       { proto_version: VarInt, server_address: String, server_port: u16, next_state: VarInt }
-    // Status
-    0x00 => StatusResponse                  { response: String }
-    0x00 => StatusRequest {}
-    0x01 => StatusPing                      { time: i64 }
-    // Login
-    // 0x00 => LoginDisconnect                 { reason: Chat } // same as 0x40 client?
-    0x00 => LoginStart                      { name: String }
-    0x02 => LoginSuccess                    { uuid: String, username: String } // NOTE(toqueteos): uuid field is not an Uuid!
-    0x03 => LoginSetCompression             { threshold: VarInt } // same as 0x46 client?
+    Handshaking => handshake {
+        clientbound {
+            0x00 => Handshake { proto_version: Var<i32>, server_address: String, server_port: u16, next_state: Var<i32> }
+        }
+        serverbound {}
+    }
+    Play => play {
+        clientbound {
+            0x00 => KeepAlive { keep_alive_id: Var<i32> }
+            0x01 => JoinGame { entity_id: i32, gamemode: u8, dimension: i8, difficulty: u8, max_players: u8, level_type: String, reduced_debug_info: bool }
+            // 0x02 => ChatMessage { data: Chat, position: i8 }
+            0x03 => TimeUpdate { world_age: i64, time_of_day: i64 }
+            0x04 => EntityEquipment { entity_id: Var<i32>, slot: i16, item: Option<Slot> }
+            0x05 => SpawnPosition { location: i64 }
+            0x06 => UpdateHealth { health: f32, food: Var<i32>, saturation: f32 }
+            0x07 => Respawn { dimension: i32, difficulty: u8, gamemode: u8, level_type: String }
+            0x08 => PlayerPositionAndLook { x: f64, y: f64, z: f64, yaw: f32, pitch: f32, flags: i8 }
+            0x09 => HeldItemChange { slot: i8 }
+            0x0a => UseBed { entity_id: Var<i32>, location: i64 }
+            0x0b => Animation { entity_id: Var<i32>, animation: u8 }
+            // 0x0c => SpawnPlayer { entity_id: Var<i32>, player_uuid: Uuid, x: i32, y: i32, z: i32, yaw: u8, pitch: u8, current_item: i16, metadata: Metadata }
+            0x0d => CollectItem { collected_entity_id: Var<i32>, collector_entity_id: Var<i32> }
+            // 0x0e => SpawnObject { entity_id: Var<i32>, type_: i8, x: i32, y: i32, z: i32, pitch: u8, yaw: u8, data: ObjectData }
+            // 0x0f => SpawnMob { entity_id: Var<i32>, type_: u8, x: i32, y: i32, z: i32, yaw: u8, pitch: u8, velocity_x: i16, velocity_y: i16, velocity_z: i16, metadata: Metadata }
+            0x10 => SpawnPainting { entity_id: Var<i32>, title: String, location: i64, direction: u8 }
+            0x11 => SpawnExperienceOrb { entity_id: Var<i32>, x: i32, y: i32, z: i32, count: i16 }
+            0x12 => EntityVelocity { entity_id: Var<i32>, velocity_x: i16, velocity_y: i16, velocity_z: i16 }
+            0x13 => DestroyEntities { entity_ids: Arr<Var<i32>, Var<i32>> }
+            0x14 => Entity { entity_id: Var<i32> }
+            0x15 => EntityRelativeMove { entity_id: Var<i32>, delta_x: i8, delta_y: i8, delta_z: i8, on_ground: bool }
+            0x16 => EntityLook { entity_id: Var<i32>, yaw: u8, pitch: u8, on_ground: bool }
+            0x17 => EntityLookAndRelativeMove { entity_id: Var<i32>, delta_x: i8, delta_y: i8, delta_z: i8, yaw: u8, pitch: u8, on_ground: bool }
+            0x18 => EntityTeleport { entity_id: Var<i32>, x: i32, y: i32, z: i32, yaw: u8, pitch: u8, on_ground: bool }
+            0x19 => EntityHeadLook { entity_id: Var<i32>, head_yaw: u8 }
+            0x1A => EntityStatus { entity_id: i32, entity_status: i8 }
+            0x1B => AttachEntity { entity_id: i32, vehicle_id: i32, leash: bool }
+            // 0x1C => EntityMetadata { entity_id: Var<i32>, metadata: Metadata }
+            0x1D => EntityEffect { entity_id: Var<i32>, effect_id: i8, amplifier: i8, duration: Var<i32>, hide_particles: bool }
+            0x1E => RemoveEntityEffect { entity_id: Var<i32>, effect_id: i8 }
+            0x1F => SetExperience { xp_bar: f32, level: Var<i32>, xp_total: Var<i32> }
+            // 0x20 => EntityProperties { entity_id: Var<i32>, properties: Arr<i32, Property> }
+            // 0x21 => ChunkData { chunk_x: i32, chunk_z: i32, ground_up_continuous: bool, mask: u16, chunk_data: Chunk }
+            // 0x22 => MultiBlockChange { chunk_x: i32, chunk_z: i32, records: Arr<Var<i32>, Record> }
+            0x23 => BlockChange { location: i64, block_id: Var<i32> }
+            0x24 => BlockAction { location: i64, byte1: u8, byte2: u8, block_type: Var<i32> }
+            0x25 => BlockBreakAnimation { entity_id: Var<i32>, location: i64, destroy_stage: i8 }
+            // 0x26 => MapChunkBulk { sky_light_sent: bool, chunks: Custom<Vec<Chunk>> } // PROBLEM: chunks is encoded as two arrays, the first one specifying which sections of each chunk column are empty
+            // 0x27 => Explosion { x: f32, y: f32, z: f32, radius: f32, records: Arr<i32, ExplosionOffset>, player_motion_x: f32, player_motion_y: f32, player_motion_z: f32 }
+            0x28 => Effect { effect_id: i32, location: i64, data: i32, disable_relative_volume: bool }
+            0x29 => SoundEffect { name: String, effect_x: i32, effect_y: i32, effect_z: i32, volume: f32, pitch: u8 }
+            // 0x2a => Particle { particle_id: i32, long_distance: bool, x: f32, y: f32, z: f32, offset_x: f32, offset_y: f32, offset_z: f32, particle_data: f32, data: Arr<i32, Var<i32>> }
+            0x2b => ChangeGameState { reason: u8, value: f32 }
+            0x2c => SpawnGlobalEntity { entity_id: Var<i32>, type_: i8, x: i32, y: i32, z: i32 }
+            // 0x2d => OpenWindow { window_id: u8, window_type: String, window_title: Chat, slots: u8, entity_id: Custom<Option<i32>> } // PROBLEM: entity_id depends on window_type
+            0x2e => CloseWindow { window_id: u8 }
+            0x2f => SetSlot { window_id: u8, slot: i16, data: Option<Slot> }
+            0x30 => WindowItems { window_id: u8, slots: Arr<i16, Option<Slot>> }
+            0x31 => WindowProperty { window_id: u8, property: i16, value: i16 }
+            0x32 => ConfirmTransaction { window_id: u8, action_number: i16, accepted: bool }
+            // 0x33 => UpdateSign { location: i64, line0: Chat, line1: Chat, line2: Chat, line3: Chat }
+            // 0x34 => UpdateMap { item_damage: Var<i32>, scale: i8, icons: Arr<Var<i32>, MapIcon>, data: MapData } // MapData is a quirky format holding optional pixel data for an arbitrary rectangle on the map
+            // 0x35 => UpdateBlockEntity { location: i64, action: u8, nbt_data: Nbt } // PROBLEM: nbt_data is omitted entirely if it encodes an empty NBT tag
+            0x36 => SignEditorOpen { location: i64 }
+            // 0x37 => Statistics { stats: Arr<Var<i32>, Stat> }
+            // 0x38 => PlayerListItem { action: Var<i32>, players: Arr<Var<i32>, PlayerListItem> }
+            0x39 => PlayerAbilities { flags: i8, flying_speed: f32, walking_speed: f32 }
+            0x3a => TabComplete { matches: Arr<Var<i32>, String> }
+            // 0x3b => ScoreboardObjective { objective_name: String, mode: ScoreMode }
+            // 0x3c => UpdateScore { score_name: String, action: ScoreAction }
+            0x3d => DisplayScoreboard { position: i8, score_name: String }
+            // 0x3e => Teams { team_name: String, team: TeamMode }
+            // 0x3f => PluginMessage { channel: String, data: Custom<Vec<u8>> } // PROBLEM: length of `data` comes from packet length
+            // 0x40 => Disconnect { reason: Chat }
+            0x41 => ServerDifficulty { difficulty: u8 }
+            // 0x42 => CombatEvent { event: CombatEvent }
+            0x43 => Camera { camera_id: Var<i32> }
+            // 0x44 => WorldBorder { action: WorldBorderAction }
+            // 0x45 => Title { action: TitleAction }
+            0x46 => SetCompression { threshold: Var<i32> }
+            // 0x47 => PlayerListHeaderFooter { header: Chat, footer: Chat }
+            0x48 => ResourcePackSend { url: String, hash: String }
+            0x49 => UpdateEntityNbt { entity_id: Var<i32>, tag: Nbt }
+        }
+        serverbound {
+            0x00 => KeepAlive { keep_alive_id: i32 }
+            0x01 => ChatMessage { message: String }
+            // 0x02 => UseEntity { target: i32, use_type: UseType }
+            0x03 => Player { on_ground: bool }
+            0x04 => PlayerPosition { x: f64, y: f64, z: f64, on_ground: bool }
+            0x05 => PlayerLook { yaw: f32, pitch: f32, on_ground: bool }
+            0x06 => PlayerPositionAndLook { x: f64, y: f64, z: f64, yaw: f32, pitch: f32, on_ground: bool }
+            0x07 => PlayerDigging { status: i8, location: i64, face: i8 }
+            // 0x08 => PlayerBlockPlacement { location: i64, direction: i8, held_item: Nbt, cursor_x: i8, cursor_y: i8, cursor_z: i8 }
+            0x09 => HeldItemChange { slot: i16 }
+            0x0a => Animation {}
+            0x0b => EntityAction { entity_id: i32, action_id: i32, jump_boost: i32 }
+            0x0c => SteerVehicle { sideways: f32, forward: f32, flags: u8 }
+            0x0d => CloseWindow { window_id: i8 }
+            // 0x0e => ClickWindow { window_id: i8, slot: i16, button: i8, action_number: i16, mode: i8, clicked_item: Nbt }
+            0x0f => ConfirmTransaction { window_id: i8, action_number: i16, accepted: bool }
+            0x10 => CreativeInventoryAction { slot: i16, clicked_item: i16 }
+            0x11 => EnchantItem { window_id: i8, enchantment: i8 }
+            0x12 => UpdateSign { location: i64, line0: String, line1: String, line2: String, line3: String }
+            0x13 => PlayerAbilities { flags: i8, flying_speed: f32, walking_speed: f32 }
+            // 0x14 => TabComplete { text: String, block_position: TabPosition }
+            0x15 => ClientSettings { locale: String, view_distance: i8, chat_mode: i8, chat_colors: bool, displayed_skin_parts: u8 }
+            0x16 => ClientStatus { action_id: i32 }
+            // 0x17 => PluginMessage { channel: String, data: Vec<u8> }
+            0x18 => Spectate { target_player: Uuid }
+            0x19 => ResourcePackStatus { hash: String, result: i32 }
+        }
+    }
+    Status => status {
+        clientbound {
+            0x00 => StatusResponse { response: String }
+            0x01 => Pong { time: i64 }
+        }
+        serverbound {
+            0x00 => StatusRequest {}
+            0x01 => Ping { time: i64 }
+        }
+    }
+    Login => login {
+        clientbound {
+            // 0x00 => LoginDisconnect { reason: Chat }
+            0x01 => EncryptionRequest { server_id: String, pubkey: Arr<Var<i32>, u8>, verify_token: Arr<Var<i32>, u8> }
+            0x02 => LoginSuccess { uuid: String, username: String } // NOTE(toqueteos): uuid field is not an Uuid!
+            0x03 => SetCompression { threshold: Var<i32> }
+        }
+        serverbound {
+            0x00 => LoginStart { name: String }
+            0x01 => EncryptionResponse { shared_secret: Arr<Var<i32>, u8>, verify_token: Arr<Var<i32>, u8> }
+        }
+    }
 }

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -465,7 +465,7 @@ packets! {
         }
         serverbound {
             0x00 => KeepAlive { keep_alive_id: i32 }
-            // 0x01 => ChatMessage { message: Chat }
+            0x01 => ChatMessage { message: String }
             // 0x02 => UseEntity { target_eid: i32, use_type: EntityUseAction }
             0x03 => PlayerIdle { on_ground: bool }
             0x04 => PlayerPosition { x: f64, y: f64, z: f64, on_ground: bool }

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -125,7 +125,7 @@ macro_rules! packets {
             pub mod $state_mod {
                 pub mod clientbound {
                     #![allow(unused_imports)]
-                    use packet::{BlockChangeRecord, Packet, Protocol, Stat, State};
+                    use packet::{BlockChangeRecord, ExplosionOffset, Packet, Protocol, Stat, State};
                     use types::{Arr, Nbt, Slot, Var};
 
                     use std::io;
@@ -142,7 +142,7 @@ macro_rules! packets {
 
                 pub mod serverbound {
                     #![allow(unused_imports)]
-                    use packet::{BlockChangeRecord, Packet, Protocol, Stat, State};
+                    use packet::{BlockChangeRecord, ExplosionOffset, Packet, Protocol, Stat, State};
                     use types::{Arr, Nbt, Slot, Var};
 
                     use std::io;
@@ -367,6 +367,12 @@ proto_structs! {
         block_id: Var<i32>
     }
 
+    ExplosionOffset {
+        x: i8,
+        y: i8,
+        z: i8
+    }
+
     Stat {
         name: String,
         value: Var<i32>
@@ -421,7 +427,7 @@ packets! {
             0x24 => BlockAction { location: i64, byte1: u8, byte2: u8, block_type: Var<i32> }
             0x25 => BlockBreakAnimation { entity_id: Var<i32>, location: i64, destroy_stage: i8 }
             // 0x26 => MapChunkBulk { sky_light_sent: bool, chunks: Vec<Chunk>; encode { ... }; decode { ... }; } // PROBLEM: chunks is encoded as two arrays, the first one specifying which sections of each chunk column are empty
-            // 0x27 => Explosion { x: f32, y: f32, z: f32, radius: f32, records: Arr<i32, ExplosionOffset>, player_motion_x: f32, player_motion_y: f32, player_motion_z: f32 }
+            0x27 => Explosion { x: f32, y: f32, z: f32, radius: f32, records: Arr<i32, ExplosionOffset>, player_motion_x: f32, player_motion_y: f32, player_motion_z: f32 }
             0x28 => Effect { effect_id: i32, location: i64, data: i32, disable_relative_volume: bool }
             0x29 => SoundEffect { name: String, x: i32, y: i32, z: i32, volume: f32, pitch: u8 }
             // 0x2a => Particle { particle_id: i32, long_distance: bool, x: f32, y: f32, z: f32, offset_x: f32, offset_y: f32, offset_z: f32, particle_data: f32, particle_count: i32, data: Vec<i32>; encode { ... }; decode { ... }; } // PROBLEM: length of data depends on particle_id

--- a/src/types/arr.rs
+++ b/src/types/arr.rs
@@ -1,10 +1,10 @@
 //! Minecraft protocol length-prefixed array data type
 
+use std::io;
+use std::io::prelude::*;
 use std::iter::{ AdditiveIterator, FromIterator };
 use std::marker::PhantomData;
 use std::num::{ NumCast, ToPrimitive };
-use std::io;
-use std::io::prelude::*;
 
 use packet::Protocol;
 
@@ -41,13 +41,13 @@ mod tests {
     use std::io;
 
     use packet::Protocol;
-    use types::VarInt;
+    use types::Var;
 
     #[test]
     fn arr_encode_i8_varint() {
         let mut dst = Vec::new();
         let value = vec![0i32, -1i32];
-        <Arr<i8, VarInt> as Protocol>::proto_encode(&value, &mut dst).unwrap();
+        <Arr<i8, Var<i32>> as Protocol>::proto_encode(&value, &mut dst).unwrap();
         let bytes = vec![2, 0, 0xff, 0xff, 0xff, 0xff, 0xf];
         assert_eq!(&dst, &bytes);
     }
@@ -57,7 +57,7 @@ mod tests {
         let bytes = vec![2, 0, 0xff, 0xff, 0xff, 0xff, 0xf];
         let arr = vec![0i32, -1i32];
         let mut src = io::Cursor::new(bytes);
-        let value = <Arr<i8, VarInt> as Protocol>::proto_decode(&mut src).unwrap();
+        let value = <Arr<i8, Var<i32>> as Protocol>::proto_decode(&mut src).unwrap();
         assert_eq!(arr, value);
     }
 

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -8,4 +8,4 @@ mod varnum;
 pub use self::arr::Arr;
 pub use self::nbt::Nbt;
 pub use self::slot::Slot;
-pub use self::varnum::{ VarInt, VarLong };
+pub use self::varnum::Var;

--- a/src/types/slot.rs
+++ b/src/types/slot.rs
@@ -6,6 +6,7 @@ use std::io::prelude::*;
 use packet::Protocol;
 use types::Nbt;
 
+#[derive(Debug)]
 pub struct Slot {
     id: u16,
     count: u8,

--- a/src/types/string.rs
+++ b/src/types/string.rs
@@ -5,7 +5,7 @@ use std::io;
 use std::io::prelude::*;
 
 use packet::Protocol;
-use types::VarInt;
+use types::Var;
 use util::ReadExactExt;
 
 /// UTF-8 string prefixed with its length as a VarInt.
@@ -14,18 +14,18 @@ impl Protocol for String {
 
     fn proto_len(value: &String) -> usize {
         let str_len = value.len();
-        <VarInt as Protocol>::proto_len(&(str_len as i32)) + str_len
+        <Var<i32> as Protocol>::proto_len(&(str_len as i32)) + str_len
     }
 
     fn proto_encode(value: &String, dst: &mut Write) -> io::Result<()> {
         let str_len = value.len() as i32;
-        try!(<VarInt as Protocol>::proto_encode(&str_len, dst));
+        try!(<Var<i32> as Protocol>::proto_encode(&str_len, dst));
         try!(dst.write_all(value.as_bytes()));
         Ok(())
     }
 
     fn proto_decode(mut src: &mut Read) -> io::Result<String> {
-        let len: i32 = try!(<VarInt as Protocol>::proto_decode(src));
+        let len: i32 = try!(<Var<i32> as Protocol>::proto_decode(src));
         let s = try!(src.read_exact(len as usize));
         String::from_utf8(s).map_err(|utf8_err| io::Error::new(io::ErrorKind::InvalidInput, "invalid String value", Some(format!("UTF-8 error: {}", utf8_err.utf8_error().description()))))
     }

--- a/src/types/varnum.rs
+++ b/src/types/varnum.rs
@@ -5,17 +5,17 @@ use byteorder::{ReadBytesExt, WriteBytesExt};
 use std::io;
 use std::io::prelude::*;
 use std::iter::range_step;
+use std::marker::PhantomData;
 
 use packet::Protocol;
 
-/// Protocol Buffer varint, encoding a two's complement signed 32-bit integer.
-#[derive(Copy, Debug)]
-pub struct VarInt;
+/// Protocol Buffer varint.
+pub struct Var<T>(PhantomData<T>);
 
-impl Protocol for VarInt {
+impl Protocol for Var<i32> {
     type Clean = i32;
 
-    /// Size in bytes of `value` as a VarInt
+    /// Size in bytes of `value` as a `Var<i32>`
     fn proto_len(value: &i32) -> usize {
         let value = *value as u32;
         for i in 1..5 {
@@ -40,7 +40,7 @@ impl Protocol for VarInt {
         }
     }
 
-    /// Reads up to 5 bytes from `src`, until a valid VarInt is found.
+    /// Reads up to 5 bytes from `src`, until a valid `Var<i32>` is found.
     #[allow(unused_variables)]
     fn proto_decode(mut src: &mut Read) -> io::Result<i32> {
         let mut x = 0i32;
@@ -58,14 +58,10 @@ impl Protocol for VarInt {
     }
 }
 
-/// Protocol Buffer varint, encoding a two's complement signed 64-bit integer.
-#[derive(Copy, Debug)]
-pub struct VarLong;
-
-impl Protocol for VarLong {
+impl Protocol for Var<i64> {
     type Clean = i64;
 
-    /// Size in bytes of `value` as a VarLong
+    /// Size in bytes of `value` as a `Var<i64>`
     fn proto_len(value: &i64) -> usize {
         let value = *value as u64;
         for i in 1..10 {
@@ -90,7 +86,7 @@ impl Protocol for VarLong {
         }
     }
 
-    /// Reads up to 10 bytes from `dst`, until a valid VarLong is found.
+    /// Reads up to 10 bytes from `dst`, until a valid `Var<i64>` is found.
     #[allow(unused_variables)]
     fn proto_decode(mut dst: &mut Read) -> io::Result<i64> {
         let mut x = 0i64;
@@ -164,7 +160,7 @@ mod tests {
         let tests = varint_tests();
         for test in tests.iter() {
             let mut r = io::Cursor::new(test.bytes.clone());
-            let value = <VarInt as Protocol>::proto_decode(&mut r).unwrap();
+            let value = <Var<i32> as Protocol>::proto_decode(&mut r).unwrap();
             assert_eq!(test.value, value);
         }
     }
@@ -174,7 +170,7 @@ mod tests {
         let tests = varint_tests();
         for test in tests.iter() {
             let mut w = Vec::new();
-            <VarInt as Protocol>::proto_encode(&test.value, &mut w).unwrap();
+            <Var<i32> as Protocol>::proto_encode(&test.value, &mut w).unwrap();
             assert_eq!(&w, &test.bytes);
         }
     }
@@ -184,7 +180,7 @@ mod tests {
         let tests = varlong_tests();
         for test in tests.iter() {
             let mut r = io::Cursor::new(test.bytes.clone());
-            let value = <VarLong as Protocol>::proto_decode(&mut r).unwrap();
+            let value = <Var<i64> as Protocol>::proto_decode(&mut r).unwrap();
             assert_eq!(test.value, value);
         }
     }
@@ -194,7 +190,7 @@ mod tests {
         let tests = varlong_tests();
         for test in tests.iter() {
             let mut w = Vec::new();
-            <VarLong as Protocol>::proto_encode(&test.value, &mut w).unwrap();
+            <Var<i64> as Protocol>::proto_encode(&test.value, &mut w).unwrap();
             assert_eq!(&w, &test.bytes);
         }
     }


### PR DESCRIPTION
This is an attempt to clean up the `packets!` macro and packets in general.
- [x] Rewrite `packets!`
- [x] Remove `Server` and `Client` prefixes from packet names
- [x] Look over all packets and fix any wrong types

Some details on what I've changed:
-   Packet types are namespaced by connection state (handshake/play/status/login) and direction (clientbound/serverbound).
-   Packets no longer implement `Protocol`, instead there is a new trait `Packet` whose `decode` method takes a packet length argument and decodes only the packet body.
-   A new type `packet::PacketEnum` can be used to exhaustively match packet types in the decoder.
-   A new function `packet::read_packet` decodes a packet from a reader and returns it wrapped inside a `PacketEnum`.
-   `packet!` has a new form for custom encode/decode implementations.

All of the above happens inside `packets!`. Additionally:
-   `VarInt` and `VarLong` are renamed to `Var<i32>` and `Var<i64>` respectively, without changing their implementations. This way we can easily move to more generic code (and things like `Var<u32>`) later if we want to.
-   I have implemented `Protocol` for `State` and `Option<T> where T: Protocol`, and used these types in packets.
-   I have added a macro `proto_structs!` for defining struct types used in the protocol and getting the `Protocol` impl for free. It's pretty much the same as the old `packet!`.
