### PR TITLE
Cleanup and reorganization of `nbt`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,4 @@ path = "src/lib.rs"
 [dependencies]
 byteorder = "*"
 uuid = "*"
+flate2 = "*"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ authors = [
 [[bin]]
 name = "hematite_server"
 path = "server/main.rs"
+doc = false
 
 [lib]
 name = "hematite_server"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 #![feature(rustc_private)]
 
 extern crate byteorder;
-extern crate flate;
+extern crate flate2;
 extern crate uuid;
 
 pub mod packet;

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -135,7 +135,6 @@ macro_rules! packets {
                     #![allow(unused_imports)]
                     use packet::{BlockChangeRecord, Packet, PacketBase, Protocol, Stat, State};
                     use types::consts::*;
-                    use types::{Arr, BlockPos, Nbt, Slot, Var};
                     use types::{Arr, BlockPos, NbtFile, Slot, Var};
 
                     use std::io;

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -136,6 +136,7 @@ macro_rules! packets {
                     use packet::{BlockChangeRecord, Packet, PacketBase, Protocol, Stat, State};
                     use types::consts::*;
                     use types::{Arr, BlockPos, Nbt, Slot, Var};
+                    use types::{Arr, BlockPos, NbtFile, Slot, Var};
 
                     use std::io;
                     use std::io::prelude::*;
@@ -154,7 +155,7 @@ macro_rules! packets {
                     #![allow(unused_imports)]
                     use packet::{BlockChangeRecord, Packet, PacketBase, Protocol, Stat, State};
                     use types::consts::*;
-                    use types::{Arr, BlockPos, Nbt, Slot, Var};
+                    use types::{Arr, BlockPos, NbtFile, Slot, Var};
 
                     use std::io;
                     use std::io::prelude::*;
@@ -481,7 +482,7 @@ packets! {
             0x46 => SetCompression { threshold: Var<i32> }
             // 0x47 => PlayerListHeaderFooter { header: Chat, footer: Chat }
             0x48 => ResourcePackSend { url: String, hash: String }
-            0x49 => UpdateEntityNbt { entity_id: Var<i32>, tag: Nbt }
+            0x49 => UpdateEntityNbt { entity_id: Var<i32>, tag: NbtFile }
         }
         serverbound {
             0x00 => KeepAlive { keep_alive_id: i32 }

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -135,7 +135,7 @@ macro_rules! packets {
                     #![allow(unused_imports)]
                     use packet::{BlockChangeRecord, Packet, PacketBase, Protocol, Stat, State};
                     use types::consts::*;
-                    use types::{Arr, BlockPos, NbtFile, Slot, Var};
+                    use types::{Arr, BlockPos, NbtBlob, Slot, Var};
 
                     use std::io;
                     use std::io::prelude::*;
@@ -154,7 +154,7 @@ macro_rules! packets {
                     #![allow(unused_imports)]
                     use packet::{BlockChangeRecord, Packet, PacketBase, Protocol, Stat, State};
                     use types::consts::*;
-                    use types::{Arr, BlockPos, NbtFile, Slot, Var};
+                    use types::{Arr, BlockPos, NbtBlob, Slot, Var};
 
                     use std::io;
                     use std::io::prelude::*;
@@ -481,7 +481,7 @@ packets! {
             0x46 => SetCompression { threshold: Var<i32> }
             // 0x47 => PlayerListHeaderFooter { header: Chat, footer: Chat }
             0x48 => ResourcePackSend { url: String, hash: String }
-            0x49 => UpdateEntityNbt { entity_id: Var<i32>, tag: NbtFile }
+            0x49 => UpdateEntityNbt { entity_id: Var<i32>, tag: NbtBlob }
         }
         serverbound {
             0x00 => KeepAlive { keep_alive_id: i32 }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -10,7 +10,7 @@ mod varnum;
 
 pub use self::arr::Arr;
 pub use self::chunk::{Chunk, ChunkColumn};
-pub use self::nbt::NbtFile;
+pub use self::nbt::{NbtFile, NbtValue};
 pub use self::pos::BlockPos;
 pub use self::slot::Slot;
 pub use self::varnum::Var;

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -10,7 +10,7 @@ mod varnum;
 
 pub use self::arr::Arr;
 pub use self::chunk::{Chunk, ChunkColumn};
-pub use self::nbt::{NbtFile, NbtValue};
+pub use self::nbt::{NbtBlob, NbtValue};
 pub use self::pos::BlockPos;
 pub use self::slot::Slot;
 pub use self::varnum::Var;

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -10,7 +10,7 @@ mod varnum;
 
 pub use self::arr::Arr;
 pub use self::chunk::{Chunk, ChunkColumn};
-pub use self::nbt::Nbt;
+pub use self::nbt::NbtFile;
 pub use self::pos::BlockPos;
 pub use self::slot::Slot;
 pub use self::varnum::Var;

--- a/src/types/nbt.rs
+++ b/src/types/nbt.rs
@@ -238,8 +238,8 @@ impl NbtFile {
     }
 
     /// Extracts an `NbtFile` from an arbitrary interface to `io::Read`.
-    pub fn from_reader(src: &mut io::Read) -> io::Result<NbtFile> {
-        let header = try!(NbtValue::read_header(&mut *src));
+    pub fn from_reader(mut src: &mut io::Read) -> io::Result<NbtFile> {
+        let header = try!(NbtValue::read_header(src));
         // Although it would be possible to read NBT files composed of
         // arbitrary objects using the current API, by convention all files
         // have a top-level Compound.
@@ -247,7 +247,7 @@ impl NbtFile {
             return Err(io::Error::new(InvalidInput, "invalid NBT file",
                        Some(format!("root value must be a Compound (0x0a)"))));
         }
-        let content = try!(NbtValue::from_reader(header.0, &mut *src));
+        let content = try!(NbtValue::from_reader(header.0, src));
         Ok(NbtFile { title: header.1, content: content })
     }
 

--- a/src/types/nbt.rs
+++ b/src/types/nbt.rs
@@ -358,6 +358,9 @@ mod tests {
             0x00
         ];
 
+        // Test correct length.
+        assert_eq!(bytes.len(), nbt.len());
+
         // We can only test if the decoded bytes match, since the HashMap does
         // not guarantee order (and so encoding is likely to be different, but
         // still correct).
@@ -375,6 +378,9 @@ mod tests {
                 0x00, 0x00,
             0x00
         ];
+
+        // Test correct length.
+        assert_eq!(bytes.len(), nbt.len());
 
         let mut dst = Vec::new();
         <NbtFile as Protocol>::proto_encode(&nbt, &mut dst).unwrap();
@@ -402,6 +408,9 @@ mod tests {
             0x00
         ];
 
+        // Test correct length.
+        assert_eq!(bytes.len(), nbt.len());
+
         let mut dst = Vec::new();
         <NbtFile as Protocol>::proto_encode(&nbt, &mut dst).unwrap();
         assert_eq!(&dst, &bytes);
@@ -422,6 +431,9 @@ mod tests {
                     0x00, 0x00, 0x00, 0x00,
             0x00
         ];
+
+        // Test correct length.
+        assert_eq!(bytes.len(), nbt.len());
 
         let mut dst = Vec::new();
         <NbtFile as Protocol>::proto_encode(&nbt, &mut dst).unwrap();

--- a/src/types/nbt.rs
+++ b/src/types/nbt.rs
@@ -426,6 +426,7 @@ mod tests {
 
     use std::collections::HashMap;
     use std::io;
+    use std::io::ErrorKind::InvalidInput;
 
     use packet::Protocol;
 
@@ -537,5 +538,20 @@ mod tests {
         let mut dst = Vec::new();
         <Nbt as Protocol>::proto_encode(&nbt, &mut dst).unwrap();
         assert_eq!(&dst, &bytes);
+    }
+
+    #[test]
+    fn nbt_no_root() {
+        let bytes = vec![0x00];
+        // Will fail, because the root is not a compound.
+        assert!(Nbt::from_reader(&mut io::Cursor::new(bytes.as_slice())).is_err());
+    }
+
+    #[test]
+    fn nbt_bad_compression() {
+        // These aren't in the zlib or gzip format, so they'll fail.
+        let bytes = vec![0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00];
+        assert!(Nbt::from_gzip(bytes.as_slice()).is_err());
+        assert!(Nbt::from_zlib(bytes.as_slice()).is_err());
     }
 }

--- a/src/types/nbt.rs
+++ b/src/types/nbt.rs
@@ -382,9 +382,15 @@ mod tests {
         // Test correct length.
         assert_eq!(bytes.len(), nbt.len());
 
+        // Test encoding.
         let mut dst = Vec::new();
         <NbtFile as Protocol>::proto_encode(&nbt, &mut dst).unwrap();
         assert_eq!(&dst, &bytes);
+
+        // Test decoding.
+        let mut src = io::Cursor::new(bytes);
+        let file = <NbtFile as Protocol>::proto_decode(&mut src).unwrap();
+        assert_eq!(&file, &nbt);
     }
 
     #[test]
@@ -411,9 +417,15 @@ mod tests {
         // Test correct length.
         assert_eq!(bytes.len(), nbt.len());
 
+        // Test encoding.
         let mut dst = Vec::new();
         <NbtFile as Protocol>::proto_encode(&nbt, &mut dst).unwrap();
         assert_eq!(&dst, &bytes);
+
+        // Test decoding.
+        let mut src = io::Cursor::new(bytes);
+        let file = <NbtFile as Protocol>::proto_decode(&mut src).unwrap();
+        assert_eq!(&file, &nbt);
     }
 
     #[test]
@@ -435,9 +447,15 @@ mod tests {
         // Test correct length.
         assert_eq!(bytes.len(), nbt.len());
 
+        // Test encoding.
         let mut dst = Vec::new();
         <NbtFile as Protocol>::proto_encode(&nbt, &mut dst).unwrap();
         assert_eq!(&dst, &bytes);
+
+        // Test decoding.
+        let mut src = io::Cursor::new(bytes);
+        let file = <NbtFile as Protocol>::proto_decode(&mut src).unwrap();
+        assert_eq!(&file, &nbt);
     }
 
     #[test]

--- a/src/types/nbt.rs
+++ b/src/types/nbt.rs
@@ -1,10 +1,10 @@
 //! MC Named Binary Tag type.
 
-use byteorder::{BigEndian, WriteBytesExt};
+use byteorder::{ByteOrder, BigEndian, WriteBytesExt, ReadBytesExt};
+use byteorder::Error::{UnexpectedEOF, Io};
 
 use std::collections::HashMap;
 use std::io;
-use std::io::prelude::*;
 use std::io::ErrorKind::InvalidInput;
 use std::iter::AdditiveIterator;
 use std::ops::Index;
@@ -16,8 +16,7 @@ use flate::{ inflate_bytes, inflate_bytes_zlib };
 
 /// Represents a NBT value
 #[derive(Clone, Debug, PartialEq)]
-pub enum Nbt {
-    End,
+pub enum NbtValue {
     Byte(i8),
     Short(i16),
     Int(i32),
@@ -26,41 +25,224 @@ pub enum Nbt {
     Double(f64),
     ByteArray(Vec<i8>),
     String(String),
-    List(List),
-    Compound(Compound),
+    List(Vec<NbtValue>),
+    Compound(HashMap<String, NbtValue>),
     IntArray(Vec<i32>),
 }
 
-/// An ordered list of NBT values.
-#[derive(Clone, Debug, PartialEq)]
-pub enum List {
-    Byte(Vec<i8>),
-    Short(Vec<i16>),
-    Int(Vec<i32>),
-    Long(Vec<i64>),
-    Float(Vec<f32>),
-    Double(Vec<f64>),
-    ByteArray(Vec<Vec<i8>>),
-    String(Vec<String>),
-    List(Vec<List>),
-    Compound(Vec<Compound>),
-    IntArray(Vec<Vec<i32>>),
-}
-
-/// An unordered list of named NBT values.
-pub type Compound = HashMap<String, Nbt>;
-
-impl Nbt {
-    /// Decodes a NBT value from `r`
-    ///
-    /// Every NBT file will always begin with a TAG_COMPOUND (0x0a). No
-    /// exceptions.
-    pub fn from_reader(src: &mut Read) -> io::Result<Nbt> {
-        <Nbt as Protocol>::proto_decode(src)
+impl NbtValue {
+    /// The type ID of this `NbtValue`, which is a single byte in the range
+    /// `0x01` to `0x0b`.
+    pub fn id(&self) -> u8 {
+        match *self {
+            NbtValue::Byte(_)      => 0x01,
+            NbtValue::Short(_)     => 0x02,
+            NbtValue::Int(_)       => 0x03,
+            NbtValue::Long(_)      => 0x04,
+            NbtValue::Float(_)     => 0x05,
+            NbtValue::Double(_)    => 0x06,
+            NbtValue::ByteArray(_) => 0x07,
+            NbtValue::String(_)    => 0x08,
+            NbtValue::List(_)      => 0x09,
+            NbtValue::Compound(_)  => 0x0a,
+            NbtValue::IntArray(_)  => 0x0b
+        }
     }
 
-    /// Extracts an `Nbt` value from compressed gzip data.
-    pub fn from_gzip(data: &[u8]) -> io::Result<Nbt> {
+    /// The length of the payload of this `NbtValue`, in bytes.
+    pub fn len(&self) -> usize {
+        match *self {
+            NbtValue::Byte(_)            => 1,
+            NbtValue::Short(_)           => 2,
+            NbtValue::Int(_)             => 4,
+            NbtValue::Long(_)            => 8,
+            NbtValue::Float(_)           => 4,
+            NbtValue::Double(_)          => 8,
+            NbtValue::ByteArray(ref val) => 4 + val.len(), // size + bytes
+            NbtValue::String(ref val)    => 2 + val.len(), // size + bytes
+            NbtValue::List(ref vals)     => {
+                // tag + size + payload for each element
+                5 + vals.iter().map(|x| x.len()).sum()
+            },
+            NbtValue::Compound(ref vals) => {
+                vals.iter().map(|(name, nbt)| {
+                    // tag + name + payload for each entry
+                    3 + name.len() + nbt.len()
+                }).sum() + 1 // + u8 for the Tag_End
+            },
+            NbtValue::IntArray(ref val)  => 4 + 4 * val.len(),
+        }
+    }
+
+    pub fn write_header(&self, sink: &mut io::Write, title: &String) -> io::Result<()> {
+        try!((&mut *sink).write_u8(self.id()));
+        try!((&mut *sink).write_u16::<BigEndian>(title.len() as u16));
+        (&mut *sink).write_all(title.as_slice().as_bytes())
+    }
+
+    /// Writes the payload of this NbtValue value to the specified `Write` sink. To
+    /// include the name, use `write_with_name()`.
+    pub fn write(&self, sink: &mut io::Write) -> io::Result<()> {
+        let res = match *self {
+            NbtValue::Byte(val)   => (&mut *sink).write_i8(val),
+            NbtValue::Short(val)  => (&mut *sink).write_i16::<BigEndian>(val),
+            NbtValue::Int(val)    => (&mut *sink).write_i32::<BigEndian>(val),
+            NbtValue::Long(val)   => (&mut *sink).write_i64::<BigEndian>(val),
+            NbtValue::Float(val)  => (&mut *sink).write_f32::<BigEndian>(val),
+            NbtValue::Double(val) => (&mut *sink).write_f64::<BigEndian>(val),
+            NbtValue::ByteArray(ref vals) => {
+                try!((&mut *sink).write_i32::<BigEndian>(vals.len() as i32));
+                for &byte in vals {
+                    try!((&mut *sink).write_i8(byte));
+                }
+                return Ok(());
+            },
+            NbtValue::String(ref val) => {
+                try!((&mut *sink).write_u16::<BigEndian>(val.len() as u16));
+                return (&mut *sink).write_all(val.as_slice().as_bytes());
+            },
+            NbtValue::List(ref vals) => {
+                // This is a bit of a trick: if the list is empty, don't bother
+                // checking its type.
+                if vals.len() == 0 {
+                    try!((&mut *sink).write_u8(1));
+                } else {
+                    // Otherwise, use the first element of the list.
+                    try!((&mut *sink).write_u8(vals[0].id()));
+                }
+                try!((&mut *sink).write_i32::<BigEndian>(vals.len() as i32));
+                for nbt in vals {
+                    try!(nbt.write(sink));
+                }
+                return Ok(());
+            },
+            NbtValue::Compound(ref vals)  => {
+                for (name, ref nbt) in vals {
+                    // Write the header for the tag.
+                    try!(nbt.write_header(sink, &name));
+                    try!(nbt.write(sink));
+                }
+                // Write the marker for the end of the Compound.
+                (&mut *sink).write_u8(0x00)
+            }
+            NbtValue::IntArray(ref vals) => {
+                try!((&mut *sink).write_i32::<BigEndian>(vals.len() as i32));
+                for &nbt in vals {
+                    try!((&mut *sink).write_i32::<BigEndian>(nbt));
+                }
+                return Ok(());
+            },
+        };
+        // Since byteorder has slightly different errors than io, we need to
+        // awkwardly wrap the results.
+        match res {
+            Err(UnexpectedEOF) => Err(io::Error::new(InvalidInput, "invalid byte ordering", None)),
+            Err(Io(e)) => Err(e),
+            Ok(_) => Ok(())
+        }
+    }
+
+    pub fn read_header(src: &mut io::Read) -> io::Result<(u8, String)> {
+        let id = try!((&mut *src).read_u8());
+        if id == 0x00 { return Ok((0x00, "".to_string())); }
+        // Extract the name.
+        let name_len = try!((&mut *src).read_u16::<BigEndian>());
+        let name = if name_len != 0 {
+            let bytes = try!((&mut *src).read_exact(name_len as usize));
+            match String::from_utf8(bytes) {
+                Ok(v) => v,
+                Err(e) => return Err(io::Error::new(InvalidInput, "string is not UTF-8", Some(format!("{}", e))))
+            }
+        } else {
+            "".to_string()
+        };
+        Ok((id, name))
+    }
+
+    pub fn from_reader(id: u8, src: &mut io::Read) -> io::Result<NbtValue> {
+        match id {
+            0x01 => Ok(NbtValue::Byte(try!((&mut *src).read_i8()))),
+            0x02 => Ok(NbtValue::Short(try!((&mut *src).read_i16::<BigEndian>()))),
+            0x03 => Ok(NbtValue::Int(try!((&mut *src).read_i32::<BigEndian>()))),
+            0x04 => Ok(NbtValue::Long(try!((&mut *src).read_i64::<BigEndian>()))),
+            0x05 => Ok(NbtValue::Float(try!((&mut *src).read_f32::<BigEndian>()))),
+            0x06 => Ok(NbtValue::Double(try!((&mut *src).read_f64::<BigEndian>()))),
+            0x07 => { // ByteArray
+                let len = try!((&mut *src).read_i32::<BigEndian>()) as usize;
+                let mut buf = Vec::with_capacity(len);
+                for _ in range(0, len) {
+                    buf.push(try!((&mut *src).read_i8()));
+                }
+                Ok(NbtValue::ByteArray(buf))
+            },
+            0x08 => { // String
+                let len = try!((&mut *src).read_u16::<BigEndian>()) as usize;
+                let bytes = try!((&mut *src).read_exact(len as usize));
+                match String::from_utf8(bytes) {
+                    Ok(v)  => Ok(NbtValue::String(v)),
+                    Err(e) => return Err(io::Error::new(InvalidInput, "string is not UTF-8", Some(format!("{}", e))))
+                }
+            },
+            0x09 => { // List
+                let id = try!((&mut *src).read_u8());
+                let len = try!((&mut *src).read_i32::<BigEndian>()) as usize;
+                let mut buf = Vec::with_capacity(len);
+                for _ in range(0, len) {
+                    buf.push(try!(NbtValue::from_reader(id, src)));
+                }
+                Ok(NbtValue::List(buf))
+            },
+            0x0a => { // Compound
+                let mut buf = HashMap::new();
+                loop {
+                    let (id, name) = try!(NbtValue::read_header(src));
+                    if id == 0x00 { break; }
+                    let tag = try!(NbtValue::from_reader(id, src));
+                    buf.insert(name, tag);
+                }
+                Ok(NbtValue::Compound(buf))
+            },
+            0x0b => { // IntArray
+                let len = try!((&mut *src).read_i32::<BigEndian>()) as usize;
+                let mut buf = Vec::with_capacity(len);
+                for _ in range(0, len) {
+                    buf.push(try!((&mut *src).read_i32::<BigEndian>()));
+                }
+                Ok(NbtValue::IntArray(buf))
+            },
+            _ => Err(io::Error::new(InvalidInput, "invalid NbtValue id", None))
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct NbtFile {
+    title: String,
+    content: NbtValue
+}
+
+impl NbtFile {
+    pub fn new(title: String) -> NbtFile {
+        let map: HashMap<String, NbtValue> = HashMap::new();
+        NbtFile { title: title, content: NbtValue::Compound(map) }
+    }
+
+    /// Extracts an `NbtFile` from an arbitrary interface to `io::Read`.
+    pub fn from_reader(src: &mut io::Read) -> io::Result<NbtFile> {
+        let header = try!(NbtValue::read_header(&mut *src));
+        // Although it would be possible to read NBT files composed of
+        // arbitrary objects using the current API, by convention all files
+        // have a top-level Compound.
+        if header.0 != 0x0a {
+            return Err(io::Error::new(InvalidInput, "invalid NBT file",
+                       Some(format!("root value must be a Compound (0x0a)"))));
+        }
+        let content = try!(NbtValue::from_reader(header.0, &mut *src));
+        Ok(NbtFile { title: header.1, content: content })
+    }
+
+    /// Extracts an `NbtFile` value from compressed gzip data.
+    pub fn from_gzip(data: &[u8]) -> io::Result<NbtFile> {
         // Check for the correct gzip header.
         if &data[..4] != [0x1f, 0x8b, 0x08, 0x00].as_slice() {
             return Err(io::Error::new(InvalidInput, "invalid gzip file", None));
@@ -71,352 +253,63 @@ impl Nbt {
             Some(v) => v,
             None    => return Err(io::Error::new(InvalidInput, "invalid gzip file", None))
         };
-        Nbt::from_reader(&mut io::Cursor::new(data.as_slice()))
+        NbtFile::from_reader(&mut io::Cursor::new(data.as_slice()))
     }
 
-    /// Extracts an `Nbt` value from compressed zlib data.
-    pub fn from_zlib(data: &[u8]) -> io::Result<Nbt> {
+    /// Extracts an `NbtFile` value from compressed zlib data.
+    pub fn from_zlib(data: &[u8]) -> io::Result<NbtFile> {
         // flake::inflate_bytes_zlib returns None in case of failure; turn this
         // into an io::Error instead.
         let data = match inflate_bytes_zlib(data) {
             Some(v) => v,
             None    => return Err(io::Error::new(InvalidInput, "invalid zlib file", None))
         };
-        Nbt::from_reader(&mut io::Cursor::new(data.as_slice()))
+        NbtFile::from_reader(&mut io::Cursor::new(data.as_slice()))
     }
 
-    pub fn as_byte(&self) -> Option<i8> {
-        match *self { Nbt::Byte(b) => Some(b), _ => None }
+    pub fn write(&self, sink: &mut io::Write) -> io::Result<()> {
+        try!(self.content.write_header(sink, &self.title));
+        self.content.write(sink)
     }
-    pub fn into_compound(self) -> Result<Compound, Nbt> {
-        match self { Nbt::Compound(c) => Ok(c), x => Err(x) }
-    }
-    pub fn into_compound_list(self) -> Result<Vec<Compound>, Nbt> {
-        match self { Nbt::List(List::Compound(c)) => Ok(c), x => Err(x) }
-    }
-    pub fn as_bytearray<'a>(&'a self) -> Option<&'a [i8]> {
-        match *self { Nbt::ByteArray(ref b) => Some(b.as_slice()), _ => None }
-    }
-    pub fn into_bytearray(self) -> Result<Vec<i8>, Nbt> {
-        match self { Nbt::ByteArray(b) => Ok(b), x => Err(x) }
-    }
-    // pub fn as_float_list<'a>(&'a self) -> Option<&'a [f32]> {
-    //     match *self { NbtList(FloatList(ref f)) => Some(f.as_slice()), _ => None }
-    // }
-    // pub fn as_double_list<'a>(&'a self) -> Option<&'a [f64]> {
-    //     match *self { NbtList(DoubleList(ref d)) => Some(d.as_slice()), _ => None }
-    // }
 
-    fn id(&self) -> u8 {
-        match *self {
-            Nbt::End => 0,
-            Nbt::Byte(_) => 1,
-            Nbt::Short(_) => 2,
-            Nbt::Int(_) => 3,
-            Nbt::Long(_) => 4,
-            Nbt::Float(_) => 5,
-            Nbt::Double(_) => 6,
-            Nbt::ByteArray(_) => 7,
-            Nbt::String(_) => 8,
-            Nbt::List(_) => 9,
-            Nbt::Compound(_) => 10,
-            Nbt::IntArray(_) => 11
+    pub fn insert(&mut self, name: String, value: NbtValue) -> Option<NbtValue> {
+        match self.content {
+            NbtValue::Compound(ref mut v) => v.insert(name, value),
+            _ => unreachable!()
         }
     }
 
-    fn write_str<'a>(name: &'a str, dst: &mut Write) -> io::Result<()> {
-        let len = name.len() as u16;
-        try!(<u16 as Protocol>::proto_encode(&len, dst));
-        if len != 0 { try!(dst.write_all(name.as_bytes())); }
-        Ok(())
-    }
-
-    fn read_str(mut src: &mut Read) -> io::Result<String> {
-        let len = try!(<u16 as Protocol>::proto_decode(src));
-        if len == 0 { return Ok("".to_string()); }
-        let bytes = try!(src.read_exact(len as usize));
-        match String::from_utf8(bytes) {
-            Ok(v)  => Ok(v),
-            Err(e) => Err(io::Error::new(InvalidInput, "string is not UTF-8", Some(format!("{}", e))))
-        }
-    }
-
-    fn write_i8_array(array: &Vec<i8>, dst: &mut Write) -> io::Result<()> {
-        let len = array.len() as i32;
-        try!(<i32 as Protocol>::proto_encode(&len, dst));
-        for value in array.iter() {
-            try!(<i8 as Protocol>::proto_encode(value, dst));
-        }
-        Ok(())
-    }
-
-    fn read_i8_array(src: &mut Read) -> io::Result<Vec<i8>> {
-        let length = try!(<i32 as Protocol>::proto_decode(src)) as usize;
-        let mut v = Vec::with_capacity(length);
-        for _ in range(0, length) {
-            v.push(try!(<i8 as Protocol>::proto_decode(src)));
-        }
-        Ok(v)
-    }
-
-    fn write_list<T: Protocol>(id: i8, xs: &Vec<<T as Protocol>::Clean>, dst: &mut Write) -> io::Result<()> {
-        try!(<i8 as Protocol>::proto_encode(&id, dst));
-        let len = xs.len() as i32;
-        try!(<i32 as Protocol>::proto_encode(&len, dst));
-        for value in xs.iter() {
-            try!(<T as Protocol>::proto_encode(value, dst));
-        }
-        Ok(())
-    }
-
-    fn read_list<T: Protocol>(length: usize, src: &mut Read) -> io::Result<Vec<<T as Protocol>::Clean>> {
-        let mut v = Vec::with_capacity(length);
-        for _ in range(0, length) {
-            v.push(try!(<T as Protocol>::proto_decode(src)));
-        }
-        Ok(v)
-    }
-
-    fn write_compound(compound: &Compound, dst: &mut Write) -> io::Result<()> {
-        for (name, value) in compound.iter() {
-            try!(<u8 as Protocol>::proto_encode(&value.id(), dst));
-            try!(Nbt::write_str(name.as_slice(), dst));
-            match value {
-                &Nbt::End                    => {}
-                &Nbt::Byte(x)                => { try!(<i8 as Protocol>::proto_encode(&x, dst)); }
-                &Nbt::Short(x)               => { try!(<i16 as Protocol>::proto_encode(&x, dst)); }
-                &Nbt::Int(x)                 => { try!(<i32 as Protocol>::proto_encode(&x, dst)); }
-                &Nbt::Long(x)                => { try!(<i64 as Protocol>::proto_encode(&x, dst)); }
-                &Nbt::Float(x)               => { try!(<f32 as Protocol>::proto_encode(&x, dst)); }
-                &Nbt::Double(x)              => { try!(<f64 as Protocol>::proto_encode(&x, dst)); }
-                &Nbt::ByteArray(ref array)   => { try!(Nbt::write_i8_array(array, dst)); }
-                &Nbt::String(ref value)      => { try!(Nbt::write_str(value.as_slice(), dst)); }
-                &Nbt::List(ref list)         => { try!(<List as Protocol>::proto_encode(list, dst)); }
-                &Nbt::Compound(ref compound) => { try!(Nbt::write_compound(compound, dst)); }
-                &Nbt::IntArray(ref array)    => { try!(Nbt::write_i32_array(array, dst)); }
-            }
-        }
-        try!(<i8 as Protocol>::proto_encode(&0, dst)); // TAG_END
-        Ok(())
-    }
-
-    fn read_compound(src: &mut Read) -> io::Result<Compound> {
-        let mut map = HashMap::new();
-        loop {
-            let tag = try!(<i8 as Protocol>::proto_decode(src));
-            if tag == 0x00 { break }
-            let key = try!(Nbt::read_str(src));
-            let value = match tag {
-                0x00 => unreachable!(),
-                0x01 => Nbt::Byte(try!(<i8 as Protocol>::proto_decode(src))),
-                0x02 => Nbt::Short(try!(<i16 as Protocol>::proto_decode(src))),
-                0x03 => Nbt::Int(try!(<i32 as Protocol>::proto_decode(src))),
-                0x04 => Nbt::Long(try!(<i64 as Protocol>::proto_decode(src))),
-                0x05 => Nbt::Float(try!(<f32 as Protocol>::proto_decode(src))),
-                0x06 => Nbt::Double(try!(<f64 as Protocol>::proto_decode(src))),
-                0x07 => Nbt::ByteArray(try!(Nbt::read_i8_array(src))),
-                0x08 => Nbt::String(try!(Nbt::read_str(src))),
-                0x09 => Nbt::List(try!(<List as Protocol>::proto_decode(src))),
-                0x0a => Nbt::Compound(try!(Nbt::read_compound(src))),
-                0x0b => Nbt::IntArray(try!(Nbt::read_i32_array(src))),
-                value => return Err(io::Error::new(InvalidInput, "invalid NBT tag", Some(format!("tag: {}", value))))
-            };
-            map.insert(key, value);
-        }
-        Ok(map)
-    }
-
-    fn write_i32_array(array: &Vec<i32>, dst: &mut Write) -> io::Result<()> {
-        let len = array.len() as i32;
-        try!(<i32 as Protocol>::proto_encode(&len, dst));
-        for value in array.iter() {
-            try!(<i32 as Protocol>::proto_encode(value, dst));
-        }
-        Ok(())
-    }
-
-    fn read_i32_array(src: &mut Read) -> io::Result<Vec<i32>> {
-        let length = try!(<i32 as Protocol>::proto_decode(src)) as usize;
-        let mut array = Vec::with_capacity(length);
-        for _ in range(0, length) {
-            array.push(try!(<i32 as Protocol>::proto_decode(src)));
-        }
-        Ok(array)
+    /// The length of this `NbtFile`, in bytes.
+    pub fn len(&self) -> usize {
+        // tag + name + content
+        1 + 2 + self.title.as_slice().len() + self.content.len()
     }
 }
 
-impl<'a> Index<&'a str> for Nbt {
-    type Output = Nbt;
+impl<'a> Index<&'a str> for NbtFile {
+    type Output = NbtValue;
 
-    fn index<'b>(&'b self, s: &&'a str) -> &'b Nbt {
-        match *self {
-            Nbt::Compound(ref compound) => compound.get(*s).unwrap(),
-            _ => panic!("cannot index non-compound Nbt ({:?}) with '{}'", self, s)
+    fn index<'b>(&'b self, s: &&'a str) -> &'b NbtValue {
+        match self.content {
+            NbtValue::Compound(ref v) => v.get(*s).unwrap(),
+            _ => unreachable!()
         }
     }
 }
 
-impl Protocol for Nbt {
-    type Clean = Nbt;
+impl Protocol for NbtFile {
+    type Clean = NbtFile;
 
-    fn proto_len(value: &Nbt) -> usize {
-        let size = match *value {
-            Nbt::End => 0,
-            Nbt::Byte(_) => 1,
-            Nbt::Short(_) => 2,
-            Nbt::Int(_) => 4,
-            Nbt::Long(_) => 8,
-            Nbt::Float(_) => 4,
-            Nbt::Double(_) => 8,
-            Nbt::ByteArray(ref value) => 4 + value.len(),
-            Nbt::String(ref value) => 2 + value.len(),
-            Nbt::List(ref value) => <List as Protocol>::proto_len(value),
-            Nbt::Compound(ref value) => {
-                1 + value.iter().map(|(name, nbt)| {
-                    2 + name.len() + <Nbt as Protocol>::proto_len(nbt)
-                }).sum()
-            }
-            Nbt::IntArray(ref value) => 4 + 4 * value.len(),
-        };
-        1 + size // All tags are preceded by TypeId
+    fn proto_len(value: &NbtFile) -> usize {
+        value.len()
     }
 
-    fn proto_encode(value: &Nbt, dst: &mut Write) -> io::Result<()> {
-        // Write root compound
-        try!(<u8 as Protocol>::proto_encode(&0x0a, dst));
-        try!(Nbt::write_str("", dst));
-        // Write `value` contents
-        match value {
-            &Nbt::Compound(ref compound) => try!(Nbt::write_compound(compound, dst)),
-            _ => {
-                return Err(io::Error::new(InvalidInput, "invalid NBT file", Some(format!("root value must be NBT Compound"))));
-            }
-        }
-        Ok(())
+    fn proto_encode(value: &NbtFile, dst: &mut io::Write) -> io::Result<()> {
+        value.write(&mut *dst)
     }
 
-    fn proto_decode(src: &mut Read) -> io::Result<Nbt> {
-        // Read root compound
-        let id = try!(<u8 as Protocol>::proto_decode(src));
-        if id != 0x0a {
-            return Err(io::Error::new(InvalidInput, "invalid NBT file", Some(format!("root value must be NBT Compound"))));
-        }
-        try!(Nbt::read_str(src)); // compound name
-        // Read root contents
-        let nbt = try!(Nbt::read_compound(src));
-        Ok(Nbt::Compound(nbt))
-    }
-}
-
-impl Protocol for List {
-    type Clean = List;
-
-    fn proto_len(value: &List) -> usize {
-        match *value {
-            List::Byte(ref value) => 1 * value.len(),
-            List::Short(ref value) => 2 * value.len(),
-            List::Int(ref value) => 4 * value.len(),
-            List::Long(ref value) => 8 * value.len(),
-            List::Float(ref value) => 4 * value.len(),
-            List::Double(ref value) => 8 * value.len(),
-            List::ByteArray(ref value) => 4 + value.len(),
-            List::String(ref value) => 2 + value.len(),
-            List::List(ref value) => {
-                5 + value.iter().map(|c| <List as Protocol>::proto_len(c)).sum()
-            }
-            List::Compound(ref value) => {
-                1 + value.iter().map(|c| {
-                    c.iter().map(|(name, nbt)| {
-                        2 + name.len() + <Nbt as Protocol>::proto_len(nbt)
-                    }).sum()
-                }).sum()
-            }
-            List::IntArray(ref value) => 4 + 4 * value.len(),
-        }
-    }
-
-    fn proto_encode(value: &List, mut dst: &mut Write) -> io::Result<()> {
-        match value {
-            &List::Byte(ref xs) =>      try!(Nbt::write_list::<i8>(0x01, xs, dst)),
-            &List::Short(ref xs) =>     try!(Nbt::write_list::<i16>(0x02, xs, dst)),
-            &List::Int(ref xs) =>       try!(Nbt::write_list::<i32>(0x03, xs, dst)),
-            &List::Long(ref xs) =>      try!(Nbt::write_list::<i64>(0x04, xs, dst)),
-            &List::Float(ref xs) =>     try!(Nbt::write_list::<f32>(0x05, xs, dst)),
-            &List::Double(ref xs) =>    try!(Nbt::write_list::<f64>(0x06, xs, dst)),
-            &List::ByteArray(ref xs) => {
-                try!(dst.write_i8(0x07));
-                try!(dst.write_i32::<BigEndian>(xs.len() as i32));
-                for array in xs.iter() {
-                    try!(Nbt::write_i8_array(array, dst));
-                }
-            }
-            &List::String(ref xs) => {
-                try!(dst.write_i8(0x08));
-                try!(dst.write_i32::<BigEndian>(xs.len() as i32));
-                for value in xs.iter() {
-                    try!(Nbt::write_str(value.as_slice(), dst));
-                }
-            }
-            &List::List(ref xs) => try!(Nbt::write_list::<List>(0x09, xs, dst)),
-            &List::Compound(ref xs) => {
-                try!(dst.write_i8(0x0a));
-                try!(dst.write_i32::<BigEndian>(xs.len() as i32));
-                for compound in xs.iter() {
-                    try!(Nbt::write_compound(compound, dst));
-                }
-            }
-            &List::IntArray(ref xs) => {
-                try!(dst.write_i8(0x0b));
-                try!(dst.write_i32::<BigEndian>(xs.len() as i32));
-                for array in xs.iter() {
-                    try!(Nbt::write_i32_array(array, dst));
-                }
-            }
-        }
-        Ok(())
-    }
-
-    fn proto_decode(src: &mut Read) -> io::Result<List> {
-        let tag = try!(<i8 as Protocol>::proto_decode(src));
-        let length = try!(<i32 as Protocol>::proto_decode(src)) as usize;
-        match tag {
-            1 => Ok(List::Byte(try!(Nbt::read_list::<i8>(length, src)))),
-            2 => Ok(List::Short(try!(Nbt::read_list::<i16>(length, src)))),
-            3 => Ok(List::Int(try!(Nbt::read_list::<i32>(length, src)))),
-            4 => Ok(List::Long(try!(Nbt::read_list::<i64>(length, src)))),
-            5 => Ok(List::Float(try!(Nbt::read_list::<f32>(length, src)))),
-            6 => Ok(List::Double(try!(Nbt::read_list::<f64>(length, src)))),
-            7 => {
-                let mut v = Vec::with_capacity(length);
-                for _ in range(0, length) {
-                    v.push(try!(Nbt::read_i8_array(src)));
-                }
-                Ok(List::ByteArray(v))
-            }
-            8 => {
-                let mut v = Vec::with_capacity(length);
-                for _ in range(0, length) {
-                    v.push(try!(Nbt::read_str(src)));
-                }
-                Ok(List::String(v))
-            }
-            9 => Ok(List::List(try!(Nbt::read_list::<List>(length, src)))),
-            10 => {
-                let mut v = Vec::with_capacity(length);
-                for _ in range(0, length) {
-                    v.push(try!(Nbt::read_compound(src)));
-                }
-                Ok(List::Compound(v))
-            }
-            11 => {
-                let mut v = Vec::with_capacity(length);
-                for _ in range(0, length) {
-                    v.push(try!(Nbt::read_i32_array(src)));
-                }
-                Ok(List::IntArray(v))
-            }
-            value => return Err(io::Error::new(InvalidInput, "invalid NBT tag", Some(format!("tag: {}", value))))
-        }
+    fn proto_decode(src: &mut io::Read) -> io::Result<NbtFile> {
+        NbtFile::from_reader(&mut *src)
     }
 }
 

--- a/src/types/slot.rs
+++ b/src/types/slot.rs
@@ -4,14 +4,14 @@ use std::io;
 use std::io::prelude::*;
 
 use packet::Protocol;
-use types::Nbt;
+use types::NbtFile;
 
 #[derive(Debug)]
 pub struct Slot {
     id: u16,
     count: u8,
     damage: i16,
-    tag: Nbt
+    tag: NbtFile
 }
 
 impl Protocol for Option<Slot> {
@@ -19,7 +19,7 @@ impl Protocol for Option<Slot> {
 
     fn proto_len(value: &Option<Slot>) -> usize {
         match *value {
-            Some(ref slot) => 2 + 1 + 2 + <Nbt as Protocol>::proto_len(&slot.tag), // id, count, damage, tag
+            Some(ref slot) => 2 + 1 + 2 + <NbtFile as Protocol>::proto_len(&slot.tag), // id, count, damage, tag
             None => 2
         }
     }
@@ -30,7 +30,7 @@ impl Protocol for Option<Slot> {
                 try!(<i16 as Protocol>::proto_encode(&(id as i16), dst));
                 try!(<u8 as Protocol>::proto_encode(&count, dst));
                 try!(<i16 as Protocol>::proto_encode(&damage, dst));
-                try!(<Nbt as Protocol>::proto_encode(tag, dst));
+                try!(<NbtFile as Protocol>::proto_encode(tag, dst));
             }
             None => { try!(<i16 as Protocol>::proto_encode(&-1, dst)) }
         }
@@ -46,7 +46,7 @@ impl Protocol for Option<Slot> {
                 id: id as u16,
                 count: try!(<u8 as Protocol>::proto_decode(src)),
                 damage: try!(<i16 as Protocol>::proto_decode(src)),
-                tag: try!(<Nbt as Protocol>::proto_decode(src))
+                tag: try!(<NbtFile as Protocol>::proto_decode(src))
             })
         })
     }

--- a/src/types/slot.rs
+++ b/src/types/slot.rs
@@ -4,14 +4,14 @@ use std::io;
 use std::io::prelude::*;
 
 use packet::Protocol;
-use types::NbtFile;
+use types::NbtBlob;
 
 #[derive(Debug)]
 pub struct Slot {
     id: u16,
     count: u8,
     damage: i16,
-    tag: NbtFile
+    tag: NbtBlob
 }
 
 impl Protocol for Option<Slot> {
@@ -19,7 +19,7 @@ impl Protocol for Option<Slot> {
 
     fn proto_len(value: &Option<Slot>) -> usize {
         match *value {
-            Some(ref slot) => 2 + 1 + 2 + <NbtFile as Protocol>::proto_len(&slot.tag), // id, count, damage, tag
+            Some(ref slot) => 2 + 1 + 2 + <NbtBlob as Protocol>::proto_len(&slot.tag), // id, count, damage, tag
             None => 2
         }
     }
@@ -30,7 +30,7 @@ impl Protocol for Option<Slot> {
                 try!(<i16 as Protocol>::proto_encode(&(id as i16), dst));
                 try!(<u8 as Protocol>::proto_encode(&count, dst));
                 try!(<i16 as Protocol>::proto_encode(&damage, dst));
-                try!(<NbtFile as Protocol>::proto_encode(tag, dst));
+                try!(<NbtBlob as Protocol>::proto_encode(tag, dst));
             }
             None => { try!(<i16 as Protocol>::proto_encode(&-1, dst)) }
         }
@@ -46,7 +46,7 @@ impl Protocol for Option<Slot> {
                 id: id as u16,
                 count: try!(<u8 as Protocol>::proto_decode(src)),
                 damage: try!(<i16 as Protocol>::proto_decode(src)),
-                tag: try!(<NbtFile as Protocol>::proto_decode(src))
+                tag: try!(<NbtBlob as Protocol>::proto_decode(src))
             })
         })
     }


### PR DESCRIPTION
Originally, I wanted to clean up some stray `panic!`'s and add some more tests (in line with my comments on IRC), but in the process I tried simplifying and improving the whole module. I though I might submit it for review. Let me know what you think.

Generally speaking, I removed quite a lot of redundant code and rewrote & simplified the readers and writers to make them recursive. There's now a new top-level object, `NbtFile` (which could also be renamed, say, `NbtObject`) which encapsulates the idea of all NBT-encoded data being a named `Compound` and handles the high-level encoding/decoding/indexing.

There are also some new and more extensive tests. I've used them to verify that the new parsers match the output of the old ones.

Finally, the use of the `flate` crate has been replaced by the newer, better `flate2` one.
