### PR TITLE
Linkify Hematite and goals in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # hematite_server [![Build Status](https://travis-ci.org/PistonDevelopers/hematite_server.svg?branch=master)](https://travis-ci.org/PistonDevelopers/hematite_server)
 
-This is the Hematite server, an implementation of the [Minecraft][] server in [Rust][]. Some of our goals are:
+This is the [Hematite][] server, an implementation of the [Minecraft][] server in [Rust][]. Some of our [goals](https://github.com/PistonDevelopers/hematite_server/issues/3) are:
 
 *   feature parity with the “Notchian” vanilla server,
 *   increased performance,
@@ -8,5 +8,6 @@ This is the Hematite server, an implementation of the [Minecraft][] server in [R
 
 The Hematite server is currently in very early stages of development and completely unusable.
 
+[Hematite]: http://hematite.piston.rs/ (Hematite)
 [Minecraft]: https://minecraft.net/ (Minecraft)
 [Rust]: http://www.rust-lang.org/ (The Rust Programming Language)


### PR DESCRIPTION
Adds a link to [our project page](http://hematite.piston.rs/) and the goals discussion at #3.
