### PR TITLE
packet: handle ID encoding/decoding in the Packet enums for each state/direction combination.

### DIFF
--- a/src/packet.rs
+++ b/src/packet.rs
@@ -17,202 +17,96 @@ pub trait Protocol {
     fn proto_decode(src: &mut Read) -> io::Result<Self::Clean>;
 }
 
-/// Holds packet methods implemented by the `packets!` macro for all packets.
-trait PacketBase {
-    /// The packet ID.
-    fn id(&self) -> i32;
-}
+/// A trait for encoding the body of a single packet type.
+pub trait PacketWrite {
+    fn inner_len(&self) -> usize;
+    fn inner_encode(&self, dst: &mut Write) -> io::Result<()>;
 
-/// A trait for encoding/decoding the body of a single packet type.
-trait Packet: PacketBase {
-    /// Encodes the packet body and writes it to a writer.
-    fn encode(&self, dst: &mut Write) -> io::Result<()>;
-    /// Decodes the packet body from a reader.
-    fn decode(src: &mut Read, len: usize) -> io::Result<Self>;
-
-    /// The length of the packet's fields, in bytes.
-    ///
-    /// The default implementation encodes the entire packet and can panic when encoding fails.
-    fn len(&self) -> usize {
-        let mut buf = vec![];
-        self.encode(&mut buf).ok().expect("tried to get the length of a malformed packet");
-        buf.len()
-    }
-
-    /// Writes a full packet to a writer, including length and packet ID.
+    /// Writes a full packet to a writer, including length.
     ///
     /// **TODO:** add support for compression.
     fn write(&self, dst: &mut Write) -> io::Result<()> {
-        let len = <Var<i32> as Protocol>::proto_len(&self.id()) + self.len();
+        let len = self.inner_len();
         try!(<Var<i32> as Protocol>::proto_encode(&(len as i32), dst));
-        try!(<Var<i32> as Protocol>::proto_encode(&self.id(), dst));
-        try!(self.encode(dst));
-        Ok(())
+        self.inner_encode(dst)
     }
 }
 
+/// A trait for decoding any of the packet types in one ID namespace.
+pub trait PacketRead: Sized {
+    fn inner_decode(src: &mut Read) -> io::Result<Self>;
+
+    /// Reads a new packet from a reader, including length.
+    ///
+    /// **TODO:** add support for compression.
+    fn read<R: Read>(src: &mut R) -> io::Result<Self> {
+        let proto_len = try!(<Var<i32> as Protocol>::proto_decode(src));
+        Self::inner_decode(&mut src.take(proto_len as u64))
+    }
+}
+
+#[derive(Debug)]
 pub enum Direction {
     Clientbound,
     Serverbound
 }
 
-macro_rules! packet {
-    // Regular packets
-    ($name:ident ($id:expr) { $($fname:ident: $fty:ty),+ }) => {
-        #[derive(Debug)]
-        pub struct $name {
-            $(pub $fname: <$fty as Protocol>::Clean),*
-        }
+#[derive(Debug)]
+pub enum NextState {
+    Status,
+    Login
+}
 
-        impl PacketBase for $name {
-            #[allow(unused_variables)]
-            fn id(&self) -> i32 { $id }
-        }
+mod prelude {
+    pub use packet::{BlockChangeRecord, Protocol, PacketRead, PacketWrite, Stat, NextState};
+    pub use types::consts::*;
+    pub use types::{Arr, BlockPos, NbtBlob, Slot, Var};
 
-        impl Packet for $name {
-            fn len(&self) -> usize {
-                0 $(+ <$fty as Protocol>::proto_len(&self.$fname) as usize)*
-            }
+    pub use std::io;
+    pub use std::io::prelude::*;
 
-            fn encode(&self, mut dst: &mut Write) -> io::Result<()> {
-                $(try!(<$fty as Protocol>::proto_encode(&self.$fname, dst));)*
-                Ok(())
-            }
-
-            #[allow(unused_variables)]
-            fn decode(mut src: &mut Read, len: usize) -> io::Result<$name> {
-                Ok($name {
-                    $($fname: try!(<$fty as Protocol>::proto_decode(src))),*
-                })
-            }
-        }
-    };
-    // No field packets
-    ($name:ident ($id:expr) {}) => {
-        #[derive(Debug)]
-        pub struct $name;
-
-        impl PacketBase for $name {
-            #[allow(unused_variables)]
-            fn id(&self) -> i32 { $id }
-        }
-
-        impl Packet for $name {
-            #[allow(unused_variables)]
-            fn len(&self) -> usize { 0 }
-
-            #[allow(unused_variables)]
-            fn encode(&self, dst: &mut Write) -> io::Result<()> {
-                Ok(())
-            }
-
-            #[allow(unused_variables)]
-            fn decode(src: &mut Read, len: usize) -> io::Result<$name> {
-                Ok($name)
-            }
-        }
-    };
-    // Custom encode/decode packets
-    ($name:ident ($id:expr) { $($fname:ident: $fty:ty),+; $impl_packet:item }) => {
-        pub struct $name {
-            $(pub $fname: $fty),*
-        }
-
-        impl PacketBase for $name {
-            #[allow(unused_variables)]
-            fn id(&self) -> i32 { $id }
-        }
-
-        $impl_packet
-    }
+    pub use uuid::Uuid;
 }
 
 macro_rules! packets {
-    ($($state:ident => $state_mod:ident { clientbound { $($c_id:expr => $c_name:ident { $($c_packet:tt)* })* } serverbound { $($s_id:expr => $s_name:ident { $($s_packet:tt)* })* } })*) => {
-        $(
-            pub mod $state_mod {
-                pub mod clientbound {
-                    #![allow(unused_imports)]
-                    use packet::{BlockChangeRecord, Packet, PacketBase, Protocol, Stat, State};
-                    use types::consts::*;
-                    use types::{Arr, BlockPos, NbtBlob, Slot, Var};
+    ($($id:expr => $name:ident { $($packet:tt)* })*) => {
+        use packet::prelude::*;
 
-                    use std::io;
-                    use std::io::prelude::*;
-
-                    use util::ReadExactExt;
-                    use uuid::Uuid;
-
-                    $(packet!{ $c_name ($c_id) { $($c_packet)* } })*
-
-                    pub enum PacketEnum {
-                        $($c_name($c_name)),*
-                    }
-                }
-
-                pub mod serverbound {
-                    #![allow(unused_imports)]
-                    use packet::{BlockChangeRecord, Packet, PacketBase, Protocol, Stat, State};
-                    use types::consts::*;
-                    use types::{Arr, BlockPos, NbtBlob, Slot, Var};
-
-                    use std::io;
-                    use std::io::prelude::*;
-
-                    use util::ReadExactExt;
-                    use uuid::Uuid;
-
-                    $(packet!{ $s_name ($s_id) { $($s_packet)* } })*
-
-                    pub enum PacketEnum {
-                        $($s_name($s_name)),*
-                    }
-                }
-
-                pub enum PacketEnum {
-                    Clientbound(clientbound::PacketEnum),
-                    Serverbound(serverbound::PacketEnum)
-                }
-            }
-        )*
-
-        pub enum PacketEnum {
-            $($state($state_mod::PacketEnum)),*
-        }
+        $(proto_struct!{ $name { $($packet)* } })*
 
         #[derive(Debug)]
-        pub enum State {
-            $($state),*
+        pub enum Packet {
+            $($name($name)),*
         }
 
-        /// Reads a new packet from a reader, wrapping in an enum for exhaustive matching.
-        ///
-        /// **TODO:** add support for compression.
-        #[allow(dead_code)]
-        fn read_packet(direction: Direction, state: State, mut src: &mut Read) -> io::Result<PacketEnum> {
-            let proto_len = try!(<Var<i32> as Protocol>::proto_decode(src));
-            let id = try!(<Var<i32> as Protocol>::proto_decode(src));
-            let len = proto_len as usize - <Var<i32> as Protocol>::proto_len(&id);
-            match state {
-                $(State::$state => match direction {
-                    Direction::Clientbound => match id {
-                        $($c_id => Ok(PacketEnum::$state($state_mod::PacketEnum::Clientbound($state_mod::clientbound::PacketEnum::$c_name(try!(<$state_mod::clientbound::$c_name as Packet>::decode(src, len)))))),)*
-                        _ => Err(io::Error::new(io::ErrorKind::InvalidInput, "unknown packet id for clientbound packet", None))
-                    },
-                    Direction::Serverbound => match id {
-                        $($s_id => Ok(PacketEnum::$state($state_mod::PacketEnum::Serverbound($state_mod::serverbound::PacketEnum::$s_name(try!(<$state_mod::serverbound::$s_name as Packet>::decode(src, len)))))),)*
-                        _ => Err(io::Error::new(io::ErrorKind::InvalidInput, "unknown packet id for serverbound packet", None))
-                    }
-                }),*
+        impl PacketRead for Packet {
+            fn inner_decode(src: &mut Read) -> io::Result<Self> {
+                match try!(<Var<i32> as Protocol>::proto_decode(src)) {
+                    $($id => <$name as Protocol>::proto_decode(src).map(Packet::$name),)*
+                    _ => Err(io::Error::new(io::ErrorKind::InvalidInput,
+                                             "unknown packet id", None))
+                }
             }
         }
+
+        $(impl PacketWrite for $name {
+            fn inner_len(&self) -> usize {
+                let id_len = <Var<i32> as Protocol>::proto_len(&$id);
+                id_len + <Self as Protocol>::proto_len(self)
+            }
+
+            fn inner_encode(&self, dst: &mut Write) -> io::Result<()> {
+                try!(<Var<i32> as Protocol>::proto_encode(&$id, dst));
+                <Self as Protocol>::proto_encode(self, dst)
+            }
+        })*
     }
 }
 
 macro_rules! impl_protocol {
     ($name:ty, 1, $enc_name:ident, $dec_name:ident) => {
         impl Protocol for $name {
-            type Clean = $name;
+            type Clean = Self;
 
             #[allow(unused_variables)]
             fn proto_len(value: &$name) -> usize { 1 }
@@ -229,7 +123,7 @@ macro_rules! impl_protocol {
     };
     ($name:ty, $len:expr, $enc_name:ident, $dec_name:ident) => {
         impl Protocol for $name {
-            type Clean = $name;
+            type Clean = Self;
 
             #[allow(unused_variables)]
             fn proto_len(value: &$name) -> usize { $len }
@@ -247,6 +141,7 @@ macro_rules! impl_protocol {
 }
 
 macro_rules! proto_struct {
+    // Regular structs.
     ($name:ident { $($fname:ident: $fty:ty),+ }) => {
         #[derive(Debug)]
         pub struct $name {
@@ -254,10 +149,10 @@ macro_rules! proto_struct {
         }
 
         impl Protocol for $name {
-            type Clean = $name;
+            type Clean = Self;
 
             fn proto_len(value: &$name) -> usize {
-                0 $(+ <$fty as Protocol>::proto_len(&value.$fname) as usize)*
+                0 $(+ <$fty as Protocol>::proto_len(&value.$fname))*
             }
 
             fn proto_encode(value: &$name, dst: &mut Write) -> io::Result<()> {
@@ -271,6 +166,34 @@ macro_rules! proto_struct {
                 })
             }
         }
+    };
+    // No field structs (unit values).
+    ($name:ident {}) => {
+        #[derive(Debug)]
+        pub struct $name;
+
+        impl Protocol for $name {
+            type Clean = Self;
+
+            fn proto_len(_: &Self) -> usize { 0 }
+
+            fn proto_encode(_: &Self, _: &mut Write) -> io::Result<()> {
+                Ok(())
+            }
+
+            fn proto_decode(_: &mut Read) -> io::Result<$name> {
+                Ok($name)
+            }
+        }
+    };
+    // Custom encode/decode structs.
+    ($name:ident { $($fname:ident: $fty:ty),+; $impl_struct:item }) => {
+        #[derive(Debug)]
+        pub struct $name {
+            $(pub $fname: $fty),*
+        }
+
+        $impl_struct
     }
 }
 
@@ -345,29 +268,26 @@ impl<T: Protocol> Protocol for Option<T> {
     }
 }
 
-/// Encodes the `State` based on the values in the `Handshake` packet.
+/// Encodes the `NextState` based on the values in the `Handshake` packet.
 ///
-/// Can only encode `Status` and `Login` states, others will result in an error.
-impl Protocol for State {
-    type Clean = State;
+/// Only intended for encoding `Status` and `Login` states.
+impl Protocol for NextState {
+    type Clean = Self;
 
-    #[allow(unused_variables)]
-    fn proto_len(value: &State) -> usize { 1 }
+    fn proto_len(_: &Self) -> usize { 1 }
 
-    fn proto_encode(value: &State, dst: &mut Write) -> io::Result<()> {
+    fn proto_encode(value: &Self, dst: &mut Write) -> io::Result<()> {
         let i = match *value {
-            State::Status => 1,
-            State::Login => 2,
-            _ => return Err(io::Error::new(io::ErrorKind::InvalidInput, "invalid state", None))
+            NextState::Status => 1,
+            NextState::Login => 2
         };
-        try!(<Var<i32> as Protocol>::proto_encode(&i, dst));
-        Ok(())
+        <Var<i32> as Protocol>::proto_encode(&i, dst)
     }
 
-    fn proto_decode(src: &mut Read) -> io::Result<State> {
+    fn proto_decode(src: &mut Read) -> io::Result<Self> {
         match try!(<Var<i32> as Protocol>::proto_decode(src)) {
-            1 => Ok(State::Status),
-            2 => Ok(State::Login),
+            1 => Ok(NextState::Status),
+            2 => Ok(NextState::Login),
             _ => Err(io::Error::new(io::ErrorKind::InvalidInput, "invalid state", None))
         }
     }
@@ -386,167 +306,172 @@ proto_structs! {
     }
 }
 
-packets! {
-    Handshaking => handshake {
-        clientbound {
-            0x00 => Handshake { proto_version: Var<i32>, server_address: String, server_port: u16, next_state: State }
-        }
-        serverbound {}
+pub mod handshake {
+    packets! {
+        0x00 => Handshake { proto_version: Var<i32>, server_address: String, server_port: u16, next_state: NextState }
     }
-    Play => play {
-        clientbound {
-            0x00 => KeepAlive { keep_alive_id: Var<i32> }
-            0x01 => JoinGame { entity_id: i32, gamemode: u8, dimension: Dimension, difficulty: u8, max_players: u8, level_type: String, reduced_debug_info: bool }
-            // 0x02 => ChatMessage { data: Chat, position: i8 }
-            0x03 => TimeUpdate { world_age: i64, time_of_day: i64 }
-            0x04 => EntityEquipment { entity_id: Var<i32>, slot: i16, item: Option<Slot> }
-            0x05 => WorldSpawn { location: BlockPos }
-            0x06 => UpdateHealth { health: f32, food: Var<i32>, saturation: f32 }
-            0x07 => Respawn { dimension: Dimension, difficulty: u8, gamemode: u8, level_type: String }
-            0x08 => PlayerPositionAndLook { position: [f64; 3], yaw: f32, pitch: f32, flags: i8 }
-            0x09 => HeldItemChange { slot: i8 }
-            0x0a => UseBed { entity_id: Var<i32>, location: BlockPos }
-            0x0b => Animation { entity_id: Var<i32>, animation: u8 }
-            // 0x0c => SpawnPlayer { entity_id: Var<i32>, player_uuid: Uuid, position: [i32; 3], yaw: u8, pitch: u8, current_item: i16, metadata: Metadata }
-            0x0d => CollectItem { collected_eid: Var<i32>, collector_eid: Var<i32> }
-            // 0x0e => SpawnObject { entity_id: Var<i32>, type_: i8, position: [i32; 3], pitch: u8, yaw: u8, data: ObjectData }
-            // 0x0f => SpawnMob { entity_id: Var<i32>, type_: u8, position: [i32; 3], yaw: u8, pitch: u8, head_pitch: u8, velocity: [i16; 3], metadata: Metadata }
-            0x10 => SpawnPainting { entity_id: Var<i32>, title: String, location: BlockPos, direction: u8 }
-            0x11 => SpawnExperienceOrb { entity_id: Var<i32>, position: [i32; 3], count: i16 }
-            0x12 => EntityVelocity { entity_id: Var<i32>, velocity: [i16; 3] }
-            0x13 => DestroyEntities { entity_ids: Arr<Var<i32>, Var<i32>> }
-            0x14 => EntityIdle { entity_id: Var<i32> }
-            0x15 => EntityRelativeMove { entity_id: Var<i32>, delta: [i8; 3], on_ground: bool }
-            0x16 => EntityLook { entity_id: Var<i32>, yaw: u8, pitch: u8, on_ground: bool }
-            0x17 => EntityLookAndRelativeMove { entity_id: Var<i32>, delta: [i8; 3], yaw: u8, pitch: u8, on_ground: bool }
-            0x18 => EntityTeleport { entity_id: Var<i32>, position: [i32; 3], yaw: u8, pitch: u8, on_ground: bool }
-            0x19 => EntityHeadLook { entity_id: Var<i32>, head_yaw: u8 }
-            0x1A => EntityStatus { entity_id: i32, entity_status: i8 }
-            0x1B => AttachEntity { riding_eid: i32, vehicle_eid: i32, leash: bool }
-            // 0x1C => EntityMetadata { entity_id: Var<i32>, metadata: Metadata }
-            0x1D => EntityEffect { entity_id: Var<i32>, effect_id: i8, amplifier: i8, duration: Var<i32>, hide_particles: bool }
-            0x1E => RemoveEntityEffect { entity_id: Var<i32>, effect_id: i8 }
-            0x1F => SetExperience { xp_bar: f32, level: Var<i32>, xp_total: Var<i32> }
-            // 0x20 => EntityProperties { entity_id: Var<i32>, properties: Arr<i32, Property> }
-            0x21 => ChunkData { x: i32, z: i32, continuous: bool, mask: u16, chunk_data: Arr<Var<i32>, u8> }
-            0x22 => MultiBlockChange { chunk_x: i32, chunk_z: i32, records: Arr<Var<i32>, BlockChangeRecord> }
-            0x23 => BlockChange { location: BlockPos, block_id: Var<i32> }
-            0x24 => BlockAction { location: BlockPos, byte1: u8, byte2: u8, block_type: Var<i32> }
-            0x25 => BlockBreakAnimation { entity_id: Var<i32>, location: BlockPos, destroy_stage: i8 }
-            // 0x26 => MapChunkBulk { sky_light_sent: bool, chunks: Vec<Chunk>; impl Packet for MapChunkBulk { ... } } // PROBLEM: chunks is encoded as two arrays, the first one specifying which sections of each chunk column are empty
-            0x27 => Explosion { position: [f32; 3], radius: f32, records: Arr<i32, [i8; 3]>, player_motion: [f32; 3] }
-            0x28 => Effect { effect_id: i32, location: BlockPos, data: i32, disable_relative_volume: bool }
-            0x29 => SoundEffect { name: String, position: [i32; 3], volume: f32, pitch: u8 }
-            // 0x2a => Particle { particle_id: i32, long_distance: bool, position: [f32; 3], offset: [f32; 3], particle_data: f32, particle_count: i32, data: Vec<i32>; impl Packet for Particle { ... } } // PROBLEM: length of data depends on particle_id
-            0x2b => ChangeGameState { reason: u8, value: f32 }
-            0x2c => SpawnGlobalEntity { entity_id: Var<i32>, type_: i8, position: [i32; 3] }
-            // 0x2d => OpenWindow { window_id: u8, window_type: String, window_title: Chat, slots: u8, entity_id: Option<i32>; impl Packet for OpenWindow { ... } } // PROBLEM: entity_id depends on window_type
-            0x2e => CloseWindow { window_id: u8 }
-            0x2f => SetSlot { window_id: u8, slot: i16, data: Option<Slot> }
-            0x30 => WindowItems { window_id: u8, slots: Arr<i16, Option<Slot>> }
-            0x31 => WindowProperty { window_id: u8, property: i16, value: i16 }
-            0x32 => ConfirmTransaction { window_id: u8, action_number: i16, accepted: bool }
-            // 0x33 => UpdateSign { location: BlockPos, line0: Chat, line1: Chat, line2: Chat, line3: Chat }
-            // 0x34 => UpdateMap { map_id: Var<i32>, scale: i8, icons: Arr<Var<i32>, MapIcon>, data: MapData } // MapData is a quirky format holding optional pixel data for an arbitrary rectangle on the map
-            // 0x35 => UpdateBlockEntity { location: [i32; 3], action: u8, nbt_data: Nbt; impl Packet for UpdateBlockEntity { ... } } // PROBLEM: nbt_data is omitted entirely if it encodes an empty NBT tag
-            0x36 => SignEditorOpen { location: BlockPos }
-            0x37 => Statistics { stats: Arr<Var<i32>, Stat> }
-            // 0x38 => UpdatePlayerList { action: Var<i32>, players: Arr<Var<i32>, PlayerListItem>; impl Packet for UpdatePlayerList { ... } } // PROBLEM: suructure of `players` elements depends on `action`
-            0x39 => PlayerAbilities { flags: i8, flying_speed: f32, walking_speed: f32 }
-            0x3a => TabComplete { matches: Arr<Var<i32>, String> }
-            // 0x3b => ScoreboardObjective { objective_name: String, mode: ObjectiveAction }
-            // 0x3c => UpdateScore { score_name: String, action: ScoreAction }
-            0x3d => DisplayScoreboard { position: i8, score_name: String }
-            // 0x3e => UpdateTeam { team_name: String, action: TeamAction }
-            0x3f => PluginMessage { channel: String, data: Vec<u8>;
-                impl Packet for PluginMessage {
-                    fn encode(&self, mut dst: &mut Write) -> io::Result<()> {
-                        try!(<String as Protocol>::proto_encode(&self.channel, dst));
-                        try!(dst.write_all(&self.data));
-                        Ok(())
-                    }
-                    fn decode(mut src: &mut Read, len: usize) -> io::Result<PluginMessage> {
-                        Ok(PluginMessage{
-                            channel: try!(<String as Protocol>::proto_decode(src)),
-                            data: try!(src.read_exact(len)),
-                        })
-                    }
+}
+pub mod play {
+    pub mod clientbound { packets! {
+        0x00 => KeepAlive { keep_alive_id: Var<i32> }
+        0x01 => JoinGame { entity_id: i32, gamemode: u8, dimension: Dimension, difficulty: u8, max_players: u8, level_type: String, reduced_debug_info: bool }
+        // 0x02 => ChatMessage { data: Chat, position: i8 }
+        0x03 => TimeUpdate { world_age: i64, time_of_day: i64 }
+        0x04 => EntityEquipment { entity_id: Var<i32>, slot: i16, item: Option<Slot> }
+        0x05 => WorldSpawn { location: BlockPos }
+        0x06 => UpdateHealth { health: f32, food: Var<i32>, saturation: f32 }
+        0x07 => Respawn { dimension: Dimension, difficulty: u8, gamemode: u8, level_type: String }
+        0x08 => PlayerPositionAndLook { position: [f64; 3], yaw: f32, pitch: f32, flags: i8 }
+        0x09 => HeldItemChange { slot: i8 }
+        0x0a => UseBed { entity_id: Var<i32>, location: BlockPos }
+        0x0b => Animation { entity_id: Var<i32>, animation: u8 }
+        // 0x0c => SpawnPlayer { entity_id: Var<i32>, player_uuid: Uuid, position: [i32; 3], yaw: u8, pitch: u8, current_item: i16, metadata: Metadata }
+        0x0d => CollectItem { collected_eid: Var<i32>, collector_eid: Var<i32> }
+        // 0x0e => SpawnObject { entity_id: Var<i32>, type_: i8, position: [i32; 3], pitch: u8, yaw: u8, data: ObjectData }
+        // 0x0f => SpawnMob { entity_id: Var<i32>, type_: u8, position: [i32; 3], yaw: u8, pitch: u8, head_pitch: u8, velocity: [i16; 3], metadata: Metadata }
+        0x10 => SpawnPainting { entity_id: Var<i32>, title: String, location: BlockPos, direction: u8 }
+        0x11 => SpawnExperienceOrb { entity_id: Var<i32>, position: [i32; 3], count: i16 }
+        0x12 => EntityVelocity { entity_id: Var<i32>, velocity: [i16; 3] }
+        0x13 => DestroyEntities { entity_ids: Arr<Var<i32>, Var<i32>> }
+        0x14 => EntityIdle { entity_id: Var<i32> }
+        0x15 => EntityRelativeMove { entity_id: Var<i32>, delta: [i8; 3], on_ground: bool }
+        0x16 => EntityLook { entity_id: Var<i32>, yaw: u8, pitch: u8, on_ground: bool }
+        0x17 => EntityLookAndRelativeMove { entity_id: Var<i32>, delta: [i8; 3], yaw: u8, pitch: u8, on_ground: bool }
+        0x18 => EntityTeleport { entity_id: Var<i32>, position: [i32; 3], yaw: u8, pitch: u8, on_ground: bool }
+        0x19 => EntityHeadLook { entity_id: Var<i32>, head_yaw: u8 }
+        0x1A => EntityStatus { entity_id: i32, entity_status: i8 }
+        0x1B => AttachEntity { riding_eid: i32, vehicle_eid: i32, leash: bool }
+        // 0x1C => EntityMetadata { entity_id: Var<i32>, metadata: Metadata }
+        0x1D => EntityEffect { entity_id: Var<i32>, effect_id: i8, amplifier: i8, duration: Var<i32>, hide_particles: bool }
+        0x1E => RemoveEntityEffect { entity_id: Var<i32>, effect_id: i8 }
+        0x1F => SetExperience { xp_bar: f32, level: Var<i32>, xp_total: Var<i32> }
+        // 0x20 => EntityProperties { entity_id: Var<i32>, properties: Arr<i32, Property> }
+        0x21 => ChunkData { x: i32, z: i32, continuous: bool, mask: u16, chunk_data: Arr<Var<i32>, u8> }
+        0x22 => MultiBlockChange { chunk_x: i32, chunk_z: i32, records: Arr<Var<i32>, BlockChangeRecord> }
+        0x23 => BlockChange { location: BlockPos, block_id: Var<i32> }
+        0x24 => BlockAction { location: BlockPos, byte1: u8, byte2: u8, block_type: Var<i32> }
+        0x25 => BlockBreakAnimation { entity_id: Var<i32>, location: BlockPos, destroy_stage: i8 }
+        // 0x26 => MapChunkBulk { sky_light_sent: bool, chunks: Vec<Chunk>; impl Protocol for MapChunkBulk { ... } } // PROBLEM: chunks is encoded as two arrays, the first one specifying which sections of each chunk column are empty
+        0x27 => Explosion { position: [f32; 3], radius: f32, records: Arr<i32, [i8; 3]>, player_motion: [f32; 3] }
+        0x28 => Effect { effect_id: i32, location: BlockPos, data: i32, disable_relative_volume: bool }
+        0x29 => SoundEffect { name: String, position: [i32; 3], volume: f32, pitch: u8 }
+        // 0x2a => Particle { particle_id: i32, long_distance: bool, position: [f32; 3], offset: [f32; 3], particle_data: f32, particle_count: i32, data: Vec<i32>; impl Protocol for Particle { ... } } // PROBLEM: length of data depends on particle_id
+        0x2b => ChangeGameState { reason: u8, value: f32 }
+        0x2c => SpawnGlobalEntity { entity_id: Var<i32>, type_: i8, position: [i32; 3] }
+        // 0x2d => OpenWindow { window_id: u8, window_type: String, window_title: Chat, slots: u8, entity_id: Option<i32>; impl Protocol for OpenWindow { ... } } // PROBLEM: entity_id depends on window_type
+        0x2e => CloseWindow { window_id: u8 }
+        0x2f => SetSlot { window_id: u8, slot: i16, data: Option<Slot> }
+        0x30 => WindowItems { window_id: u8, slots: Arr<i16, Option<Slot>> }
+        0x31 => WindowProperty { window_id: u8, property: i16, value: i16 }
+        0x32 => ConfirmTransaction { window_id: u8, action_number: i16, accepted: bool }
+        // 0x33 => UpdateSign { location: BlockPos, line0: Chat, line1: Chat, line2: Chat, line3: Chat }
+        // 0x34 => UpdateMap { map_id: Var<i32>, scale: i8, icons: Arr<Var<i32>, MapIcon>, data: MapData } // MapData is a quirky format holding optional pixel data for an arbitrary rectangle on the map
+        // 0x35 => UpdateBlockEntity { location: [i32; 3], action: u8, nbt_data: Nbt; impl Protocol for UpdateBlockEntity { ... } } // PROBLEM: nbt_data is omitted entirely if it encodes an empty NBT tag
+        0x36 => SignEditorOpen { location: BlockPos }
+        0x37 => Statistics { stats: Arr<Var<i32>, Stat> }
+        // 0x38 => UpdatePlayerList { action: Var<i32>, players: Arr<Var<i32>, PlayerListItem>; impl Protocol for UpdatePlayerList { ... } } // PROBLEM: suructure of `players` elements depends on `action`
+        0x39 => PlayerAbilities { flags: i8, flying_speed: f32, walking_speed: f32 }
+        0x3a => TabComplete { matches: Arr<Var<i32>, String> }
+        // 0x3b => ScoreboardObjective { objective_name: String, mode: ObjectiveAction }
+        // 0x3c => UpdateScore { score_name: String, action: ScoreAction }
+        0x3d => DisplayScoreboard { position: i8, score_name: String }
+        // 0x3e => UpdateTeam { team_name: String, action: TeamAction }
+        0x3f => PluginMessage { channel: String, data: Vec<u8>;
+            impl Protocol for PluginMessage {
+                type Clean = Self;
+                fn proto_len(this: &Self) -> usize {
+                    <String as Protocol>::proto_len(&this.channel) + this.data.len()
+                }
+                fn proto_encode(this: &Self, mut dst: &mut Write) -> io::Result<()> {
+                    try!(<String as Protocol>::proto_encode(&this.channel, dst));
+                    try!(dst.write_all(&this.data));
+                    Ok(())
+                }
+                fn proto_decode(mut src: &mut Read) -> io::Result<PluginMessage> {
+                    Ok(PluginMessage{
+                        channel: try!(<String as Protocol>::proto_decode(src)),
+                        data:  { let mut data = vec![]; try!(src.read_to_end(&mut data)); data },
+                    })
                 }
             }
-            // 0x40 => Disconnect { reason: Chat }
-            0x41 => ServerDifficulty { difficulty: u8 }
-            // 0x42 => PlayCombatEvent { event: CombatEvent }
-            0x43 => Camera { camera_id: Var<i32> }
-            // 0x44 => WorldBorder { action: WorldBorderAction }
-            // 0x45 => Title { action: TitleAction }
-            0x46 => SetCompression { threshold: Var<i32> }
-            // 0x47 => PlayerListHeaderFooter { header: Chat, footer: Chat }
-            0x48 => ResourcePackSend { url: String, hash: String }
-            0x49 => UpdateEntityNbt { entity_id: Var<i32>, tag: NbtBlob }
         }
-        serverbound {
-            0x00 => KeepAlive { keep_alive_id: i32 }
-            0x01 => ChatMessage { message: String }
-            // 0x02 => UseEntity { target_eid: i32, use_type: EntityUseAction }
-            0x03 => PlayerIdle { on_ground: bool }
-            0x04 => PlayerPosition { position: [f64; 3], on_ground: bool }
-            0x05 => PlayerLook { yaw: f32, pitch: f32, on_ground: bool }
-            0x06 => PlayerPositionAndLook { position: [f64; 3], yaw: f32, pitch: f32, on_ground: bool }
-            0x07 => PlayerDigging { status: i8, location: BlockPos, face: i8 }
-            0x08 => PlayerBlockPlacement { location: BlockPos, direction: i8, held_item: Option<Slot>, cursor: [i8; 3] }
-            0x09 => HeldItemChange { slot: i16 }
-            0x0a => Animation {}
-            0x0b => EntityAction { entity_id: Var<i32>, action_id: Var<i32>, jump_boost: Var<i32> }
-            0x0c => SteerVehicle { sideways: f32, forward: f32, flags: u8 }
-            0x0d => CloseWindow { window_id: u8 }
-            0x0e => ClickWindow { window_id: u8, slot: i16, button: i8, action_number: i16, mode: i8, clicked_item: Option<Slot> }
-            0x0f => ConfirmTransaction { window_id: u8, action_number: i16, accepted: bool }
-            0x10 => CreativeInventoryAction { slot: i16, clicked_item: Option<Slot> }
-            0x11 => EnchantItem { window_id: u8, enchantment: i8 }
-            // 0x12 => UpdateSign { location: BlockPos, line0: Chat, line1: Chat, line2: Chat, line3: Chat }
-            0x13 => PlayerAbilities { flags: i8, flying_speed: f32, walking_speed: f32 }
-            0x14 => TabComplete { text: String, looking_at: Option<i64> }
-            0x15 => ClientSettings { locale: String, view_distance: i8, chat_mode: i8, chat_colors: bool, displayed_skin_parts: u8 }
-            0x16 => ClientStatus { action_id: Var<i32> }
-            0x17 => PluginMessage { channel: String, data: Vec<u8>;
-                impl Packet for PluginMessage {
-                    fn encode(&self, mut dst: &mut Write) -> io::Result<()> {
-                        try!(<String as Protocol>::proto_encode(&self.channel, dst));
-                        try!(dst.write_all(&self.data));
-                        Ok(())
-                    }
-                    fn decode(mut src: &mut Read, len: usize) -> io::Result<PluginMessage> {
-                        Ok(PluginMessage{
-                            channel: try!(<String as Protocol>::proto_decode(src)),
-                            data: try!(src.read_exact(len)),
-                        })
-                    }
+        // 0x40 => Disconnect { reason: Chat }
+        0x41 => ServerDifficulty { difficulty: u8 }
+        // 0x42 => PlayCombatEvent { event: CombatEvent }
+        0x43 => Camera { camera_id: Var<i32> }
+        // 0x44 => WorldBorder { action: WorldBorderAction }
+        // 0x45 => Title { action: TitleAction }
+        0x46 => SetCompression { threshold: Var<i32> }
+        // 0x47 => PlayerListHeaderFooter { header: Chat, footer: Chat }
+        0x48 => ResourcePackSend { url: String, hash: String }
+        0x49 => UpdateEntityNbt { entity_id: Var<i32>, tag: NbtBlob }
+    } }
+    pub mod serverbound { packets! {
+        0x00 => KeepAlive { keep_alive_id: i32 }
+        0x01 => ChatMessage { message: String }
+        // 0x02 => UseEntity { target_eid: i32, use_type: EntityUseAction }
+        0x03 => PlayerIdle { on_ground: bool }
+        0x04 => PlayerPosition { position: [f64; 3], on_ground: bool }
+        0x05 => PlayerLook { yaw: f32, pitch: f32, on_ground: bool }
+        0x06 => PlayerPositionAndLook { position: [f64; 3], yaw: f32, pitch: f32, on_ground: bool }
+        0x07 => PlayerDigging { status: i8, location: BlockPos, face: i8 }
+        0x08 => PlayerBlockPlacement { location: BlockPos, direction: i8, held_item: Option<Slot>, cursor: [i8; 3] }
+        0x09 => HeldItemChange { slot: i16 }
+        0x0a => Animation {}
+        0x0b => EntityAction { entity_id: Var<i32>, action_id: Var<i32>, jump_boost: Var<i32> }
+        0x0c => SteerVehicle { sideways: f32, forward: f32, flags: u8 }
+        0x0d => CloseWindow { window_id: u8 }
+        0x0e => ClickWindow { window_id: u8, slot: i16, button: i8, action_number: i16, mode: i8, clicked_item: Option<Slot> }
+        0x0f => ConfirmTransaction { window_id: u8, action_number: i16, accepted: bool }
+        0x10 => CreativeInventoryAction { slot: i16, clicked_item: Option<Slot> }
+        0x11 => EnchantItem { window_id: u8, enchantment: i8 }
+        // 0x12 => UpdateSign { location: BlockPos, line0: Chat, line1: Chat, line2: Chat, line3: Chat }
+        0x13 => PlayerAbilities { flags: i8, flying_speed: f32, walking_speed: f32 }
+        0x14 => TabComplete { text: String, looking_at: Option<i64> }
+        0x15 => ClientSettings { locale: String, view_distance: i8, chat_mode: i8, chat_colors: bool, displayed_skin_parts: u8 }
+        0x16 => ClientStatus { action_id: Var<i32> }
+        0x17 => PluginMessage { channel: String, data: Vec<u8>;
+            impl Protocol for PluginMessage {
+                type Clean = Self;
+                fn proto_len(this: &Self) -> usize {
+                    <String as Protocol>::proto_len(&this.channel) + this.data.len()
+                }
+                fn proto_encode(this: &Self, mut dst: &mut Write) -> io::Result<()> {
+                    try!(<String as Protocol>::proto_encode(&this.channel, dst));
+                    try!(dst.write_all(&this.data));
+                    Ok(())
+                }
+                fn proto_decode(mut src: &mut Read) -> io::Result<PluginMessage> {
+                    Ok(PluginMessage{
+                        channel: try!(<String as Protocol>::proto_decode(src)),
+                        data: { let mut data = vec![]; try!(src.read_to_end(&mut data)); data },
+                    })
                 }
             }
-            0x18 => Spectate { target_player: Uuid }
-            0x19 => ResourcePackStatus { hash: String, result: Var<i32> }
         }
-    }
-    Status => status {
-        clientbound {
-            0x00 => StatusResponse { response: String }
-            0x01 => Pong { time: i64 }
-        }
-        serverbound {
-            0x00 => StatusRequest {}
-            0x01 => Ping { time: i64 }
-        }
-    }
-    Login => login {
-        clientbound {
-            // 0x00 => Disconnect { reason: Chat }
-            0x01 => EncryptionRequest { server_id: String, pubkey: Arr<Var<i32>, u8>, verify_token: Arr<Var<i32>, u8> }
-            // 0x02 => LoginSuccess { uuid: Uuid, username: String; impl Packet for LoginSuccess { ... } } // NOTE: uuid field is encoded as a string!
-            0x03 => SetCompression { threshold: Var<i32> }
-        }
-        serverbound {
-            0x00 => LoginStart { name: String }
-            0x01 => EncryptionResponse { shared_secret: Arr<Var<i32>, u8>, verify_token: Arr<Var<i32>, u8> }
-        }
-    }
+        0x18 => Spectate { target_player: Uuid }
+        0x19 => ResourcePackStatus { hash: String, result: Var<i32> }
+    } }
+}
+pub mod status {
+    pub mod clientbound { packets! {
+        0x00 => StatusResponse { response: String }
+        0x01 => Pong { time: i64 }
+    } }
+    pub mod serverbound { packets! {
+        0x00 => StatusRequest {}
+        0x01 => Ping { time: i64 }
+    } }
+}
+pub mod login {
+    pub mod clientbound { packets! {
+        // 0x00 => Disconnect { reason: Chat }
+        0x01 => EncryptionRequest { server_id: String, pubkey: Arr<Var<i32>, u8>, verify_token: Arr<Var<i32>, u8> }
+        // 0x02 => LoginSuccess { uuid: Uuid, username: String; impl Protocol for LoginSuccess { ... } } // NOTE: uuid field is encoded as a string!
+        0x03 => SetCompression { threshold: Var<i32> }
+    } }
+    pub mod serverbound { packets! {
+        0x00 => LoginStart { name: String }
+        0x01 => EncryptionResponse { shared_secret: Arr<Var<i32>, u8>, verify_token: Arr<Var<i32>, u8> }
+    } }
 }


### PR DESCRIPTION
This is the design I discussed with @toqueteos on IRC.
It feels more idiomatic to me and it doesn't require the multiple wrapping structures.
All the `packet::$state::$direction::Packet` enums implement `packet::Packet` which provides `read` and `write` methods, higher-level than `Protocol` and abstracting over compression/encryption.
The ID encoding/decoding is done as part of those enums' `Protocol` implementation.
