### PR TITLE
Adds NBT-specific parsing/encoding/creation errors.

### DIFF
--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -10,7 +10,7 @@ mod varnum;
 
 pub use self::arr::Arr;
 pub use self::chunk::{Chunk, ChunkColumn};
-pub use self::nbt::{NbtBlob, NbtValue};
+pub use self::nbt::{NbtBlob, NbtError, NbtValue};
 pub use self::pos::BlockPos;
 pub use self::slot::Slot;
 pub use self::varnum::Var;

--- a/src/types/nbt.rs
+++ b/src/types/nbt.rs
@@ -1,13 +1,15 @@
 //! MC Named Binary Tag type.
 
 use std::collections::HashMap;
+use std::error::FromError;
 use std::io;
 use std::io::ErrorKind::InvalidInput;
 use std::iter::AdditiveIterator;
 use std::ops::Index;
+use std::string;
 
+use byteorder;
 use byteorder::{ByteOrder, BigEndian, WriteBytesExt, ReadBytesExt};
-use byteorder::Error::{UnexpectedEOF, Io};
 
 use flate2::Compression;
 use flate2::read::{GzDecoder, ZlibDecoder};
@@ -15,6 +17,71 @@ use flate2::write::{GzEncoder, ZlibEncoder};
 
 use packet::Protocol;
 use util::ReadExactExt;
+
+/// Errors that may be encountered when constructing, parsing, or encoding
+/// `NbtValue` and `NbtBlob` objects.
+///
+/// `NbtError`s can be seamlessly converted to more general `io::Error` objects
+/// using the `FromError` trait.
+#[derive(Clone, Debug, PartialEq)]
+pub enum NbtError {
+    /// Wraps errors emitted by methods during I/O operations.
+    IoError(io::Error),
+    /// Wraps errors emitted by during big/little endian encoding and decoding.
+    ByteOrderError(byteorder::Error),
+    /// An error for when an unknown type ID is encountered in decoding NBT
+    /// binary representations. Includes the ID in question.
+    InvalidTypeId(u8),
+    /// An error emitted when trying to create `NbtBlob`s with incorrect lists.
+    HeterogeneousList,
+    /// An error for when NBT binary representations do not begin with an
+    /// `NbtValue::Compound`.
+    NoRootCompound,
+    /// An error for when NBT binary representations contain invalid UTF-8
+    /// strings.
+    InvalidUtf8,
+}
+
+impl FromError<io::Error> for NbtError {
+    fn from_error(e: io::Error) -> NbtError {
+        NbtError::IoError(e)
+    }
+}
+
+impl FromError<string::FromUtf8Error> for NbtError {
+    fn from_error(_: string::FromUtf8Error) -> NbtError {
+        NbtError::InvalidUtf8
+    }
+}
+
+impl FromError<byteorder::Error> for NbtError {
+    fn from_error(err: byteorder::Error) -> NbtError {
+        // Promote byteorder's I/O errors to NbtError's I/O errors.
+        if let byteorder::Error::Io(e) = err {
+            NbtError::IoError(e)
+        } else {
+            NbtError::ByteOrderError(err)
+        }
+    }
+}
+
+impl FromError<NbtError> for io::Error {
+    fn from_error(e: NbtError) -> io::Error {
+        match e {
+            NbtError::IoError(e) => e,
+            NbtError::ByteOrderError(_) =>
+                io::Error::new(InvalidInput, "invalid byte ordering", None),
+            NbtError::InvalidTypeId(id) =>
+                io::Error::new(InvalidInput, "invalid NbtValue id", Some(format!("id = {}", id))),
+            NbtError::HeterogeneousList =>
+                io::Error::new(InvalidInput, "List values must be homogeneous", None),
+            NbtError::NoRootCompound =>
+                io::Error::new(InvalidInput, "root value must be a Compound (0x0a)", None),
+            NbtError::InvalidUtf8 =>
+                io::Error::new(InvalidInput, "string is not UTF-8", None),
+        }
+    }
+}
 
 /// A value which can be represented in the Named Binary Tag (NBT) file format.
 #[derive(Clone, Debug, PartialEq)]
@@ -78,31 +145,31 @@ impl NbtValue {
 
     /// Writes the header (that is, the value's type ID and optionally a title)
     /// of this `NbtValue` to an `io::Write` destination.
-    pub fn write_header(&self, mut dst: &mut io::Write, title: &String) -> io::Result<()> {
+    pub fn write_header(&self, mut dst: &mut io::Write, title: &String) -> Result<(), NbtError> {
         try!(dst.write_u8(self.id()));
         try!(dst.write_u16::<BigEndian>(title.len() as u16));
-        dst.write_all(title.as_slice().as_bytes())
+        try!(dst.write_all(title.as_slice().as_bytes()));
+        Ok(())
     }
 
     /// Writes the payload of this `NbtValue` to an `io::Write` destination.
-    pub fn write(&self, mut dst: &mut io::Write) -> io::Result<()> {
-        let res = match *self {
-            NbtValue::Byte(val)   => dst.write_i8(val),
-            NbtValue::Short(val)  => dst.write_i16::<BigEndian>(val),
-            NbtValue::Int(val)    => dst.write_i32::<BigEndian>(val),
-            NbtValue::Long(val)   => dst.write_i64::<BigEndian>(val),
-            NbtValue::Float(val)  => dst.write_f32::<BigEndian>(val),
-            NbtValue::Double(val) => dst.write_f64::<BigEndian>(val),
+    pub fn write(&self, mut dst: &mut io::Write) -> Result<(), NbtError> {
+        match *self {
+            NbtValue::Byte(val)   => try!(dst.write_i8(val)),
+            NbtValue::Short(val)  => try!(dst.write_i16::<BigEndian>(val)),
+            NbtValue::Int(val)    => try!(dst.write_i32::<BigEndian>(val)),
+            NbtValue::Long(val)   => try!(dst.write_i64::<BigEndian>(val)),
+            NbtValue::Float(val)  => try!(dst.write_f32::<BigEndian>(val)),
+            NbtValue::Double(val) => try!(dst.write_f64::<BigEndian>(val)),
             NbtValue::ByteArray(ref vals) => {
                 try!(dst.write_i32::<BigEndian>(vals.len() as i32));
                 for &byte in vals {
                     try!(dst.write_i8(byte));
                 }
-                return Ok(());
             },
             NbtValue::String(ref val) => {
                 try!(dst.write_u16::<BigEndian>(val.len() as u16));
-                return dst.write_all(val.as_slice().as_bytes());
+                try!(dst.write_all(val.as_slice().as_bytes()));
             },
             NbtValue::List(ref vals) => {
                 // This is a bit of a trick: if the list is empty, don't bother
@@ -110,7 +177,6 @@ impl NbtValue {
                 if vals.len() == 0 {
                     try!(dst.write_u8(1));
                     try!(dst.write_i32::<BigEndian>(0));
-                    return Ok(())
                 } else {
                     // Otherwise, use the first element of the list.
                     let first_id = vals[0].id();
@@ -119,12 +185,10 @@ impl NbtValue {
                     for nbt in vals {
                         // Ensure that all of the tags are the same type.
                         if nbt.id() != first_id {
-                            return Err(io::Error::new(InvalidInput,
-                                                      "List values must be homogeneous", None));
+                            return Err(NbtError::HeterogeneousList);
                         }
                         try!(nbt.write(dst));
                     }
-                    return Ok(())
                 }
             },
             NbtValue::Compound(ref vals)  => {
@@ -134,38 +198,28 @@ impl NbtValue {
                     try!(nbt.write(dst));
                 }
                 // Write the marker for the end of the Compound.
-                dst.write_u8(0x00)
+                try!(dst.write_u8(0x00))
             }
             NbtValue::IntArray(ref vals) => {
                 try!(dst.write_i32::<BigEndian>(vals.len() as i32));
                 for &nbt in vals {
                     try!(dst.write_i32::<BigEndian>(nbt));
                 }
-                return Ok(());
             },
         };
-        // Since byteorder has slightly different errors than io, we need to
-        // awkwardly wrap the results.
-        match res {
-            Err(UnexpectedEOF) => Err(io::Error::new(InvalidInput, "invalid byte ordering", None)),
-            Err(Io(e)) => Err(e),
-            Ok(_) => Ok(())
-        }
+        Ok(())
     }
 
     /// Reads any valid `NbtValue` header (that is, a type ID and a title of
     /// arbitrary UTF-8 bytes) from an `io::Read` source.
-    pub fn read_header(mut src: &mut io::Read) -> io::Result<(u8, String)> {
+    pub fn read_header(mut src: &mut io::Read) -> Result<(u8, String), NbtError> {
         let id = try!(src.read_u8());
         if id == 0x00 { return Ok((0x00, "".to_string())); }
         // Extract the name.
         let name_len = try!(src.read_u16::<BigEndian>());
         let name = if name_len != 0 {
             let bytes = try!(src.read_exact(name_len as usize));
-            match String::from_utf8(bytes) {
-                Ok(v) => v,
-                Err(e) => return Err(io::Error::new(InvalidInput, "string is not UTF-8", Some(format!("{}", e))))
-            }
+            try!(String::from_utf8(bytes))
         } else {
             "".to_string()
         };
@@ -174,7 +228,7 @@ impl NbtValue {
 
     /// Reads the payload of an `NbtValue` with a given type ID from an
     /// `io::Read` source.
-    pub fn from_reader(id: u8, mut src: &mut io::Read) -> io::Result<NbtValue> {
+    pub fn from_reader(id: u8, mut src: &mut io::Read) -> Result<NbtValue, NbtError> {
         match id {
             0x01 => Ok(NbtValue::Byte(try!(src.read_i8()))),
             0x02 => Ok(NbtValue::Short(try!(src.read_i16::<BigEndian>()))),
@@ -193,10 +247,7 @@ impl NbtValue {
             0x08 => { // String
                 let len = try!(src.read_u16::<BigEndian>()) as usize;
                 let bytes = try!(src.read_exact(len as usize));
-                match String::from_utf8(bytes) {
-                    Ok(v)  => Ok(NbtValue::String(v)),
-                    Err(e) => return Err(io::Error::new(InvalidInput, "string is not UTF-8", Some(format!("{}", e))))
-                }
+                Ok(NbtValue::String(try!(String::from_utf8(bytes))))
             },
             0x09 => { // List
                 let id = try!(src.read_u8());
@@ -225,7 +276,7 @@ impl NbtValue {
                 }
                 Ok(NbtValue::IntArray(buf))
             },
-            _ => Err(io::Error::new(InvalidInput, "invalid NbtValue id", None))
+            e => Err(NbtError::InvalidTypeId(e))
         }
     }
 }
@@ -267,14 +318,13 @@ impl NbtBlob {
     }
 
     /// Extracts an `NbtBlob` object from an `io::Read` source.
-    pub fn from_reader(mut src: &mut io::Read) -> io::Result<NbtBlob> {
+    pub fn from_reader(mut src: &mut io::Read) -> Result<NbtBlob, NbtError> {
         let header = try!(NbtValue::read_header(src));
         // Although it would be possible to read NBT format files composed of
         // arbitrary objects using the current API, by convention all files
         // have a top-level Compound.
         if header.0 != 0x0a {
-            return Err(io::Error::new(InvalidInput, "invalid NBT file",
-                       Some(format!("root value must be a Compound (0x0a)"))));
+            return Err(NbtError::NoRootCompound);
         }
         let content = try!(NbtValue::from_reader(header.0, src));
         Ok(NbtBlob { title: header.1, content: content })
@@ -282,7 +332,7 @@ impl NbtBlob {
 
     /// Extracts an `NbtBlob` object from an `io::Read` source that is
     /// compressed using the Gzip format.
-    pub fn from_gzip(src: &mut io::Read) -> io::Result<NbtBlob> {
+    pub fn from_gzip(src: &mut io::Read) -> Result<NbtBlob, NbtError> {
         // Reads the gzip header, and fails if it is incorrect.
         let mut data = try!(GzDecoder::new(src));
         NbtBlob::from_reader(&mut data)
@@ -290,26 +340,26 @@ impl NbtBlob {
 
     /// Extracts an `NbtBlob` object from an `io::Read` source that is
     /// compressed using the zlib format.
-    pub fn from_zlib(src: &mut io::Read) -> io::Result<NbtBlob> {
+    pub fn from_zlib(src: &mut io::Read) -> Result<NbtBlob, NbtError> {
         NbtBlob::from_reader(&mut ZlibDecoder::new(src))
     }
 
     /// Writes the binary representation of this `NbtBlob` to an `io::Write`
     /// destination.
-    pub fn write(&self, dst: &mut io::Write) -> io::Result<()> {
+    pub fn write(&self, dst: &mut io::Write) -> Result<(), NbtError> {
         try!(self.content.write_header(dst, &self.title));
         self.content.write(dst)
     }
 
     /// Writes the binary representation of this `NbtBlob`, compressed using
     /// the Gzip format, to an `io::Write` destination.
-    pub fn write_gzip(&self, dst: &mut io::Write) -> io::Result<()> {
+    pub fn write_gzip(&self, dst: &mut io::Write) -> Result<(), NbtError> {
         self.write(&mut GzEncoder::new(dst, Compression::Default))
     }
 
     /// Writes the binary representation of this `NbtBlob`, compressed using
     /// the Zlib format, to an `io::Write` dst.
-    pub fn write_zlib(&self, dst: &mut io::Write) -> io::Result<()> {
+    pub fn write_zlib(&self, dst: &mut io::Write) -> Result<(), NbtError> {
         self.write(&mut ZlibEncoder::new(dst, Compression::Default))
     }
 
@@ -317,30 +367,29 @@ impl NbtBlob {
     /// method is just a thin wrapper around the underlying `HashMap` method of
     /// the same name.
     ///
-    /// This method will also return `None` if a `NbtValue::List` with
+    /// This method will also return an error if a `NbtValue::List` with
     /// heterogeneous elements is passed in, because this is illegal in the NBT
     /// file format.
-    pub fn insert(&mut self, name: String, value: NbtValue) -> Option<NbtValue> {
+    pub fn insert(&mut self, name: String, value: NbtValue) -> Result<(), NbtError> {
         // The follow prevents `List`s with heterogeneous tags from being
         // inserted into the file. It would be nicer to return an error, but
         // this would depart from the `HashMap` API for `insert`.
-        match value {
-            NbtValue::List(ref vals) => {
-                if vals.len() != 0 {
-                    let first_id = vals[0].id();
-                    for nbt in vals {
-                        if nbt.id() != first_id {
-                            return None
-                        }
+        if let NbtValue::List(ref vals) = value {
+            if vals.len() != 0 {
+                let first_id = vals[0].id();
+                for nbt in vals {
+                    if nbt.id() != first_id {
+                        return Err(NbtError::HeterogeneousList)
                     }
                 }
-            },
-            _ => ()
-        };
-        match self.content {
-            NbtValue::Compound(ref mut v) => v.insert(name, value),
-            _ => unreachable!()
+            }
         }
+        if let NbtValue::Compound(ref mut v) = self.content {
+            v.insert(name, value);
+        } else {
+            unreachable!();
+        }
+        Ok(())
     }
 
     /// The uncompressed length of this `NbtBlob`, in bytes.
@@ -369,11 +418,11 @@ impl Protocol for NbtBlob {
     }
 
     fn proto_encode(value: &NbtBlob, mut dst: &mut io::Write) -> io::Result<()> {
-        value.write(dst)
+        Ok(try!(value.write(dst)))
     }
 
     fn proto_decode(mut src: &mut io::Read) -> io::Result<NbtBlob> {
-        NbtBlob::from_reader(src)
+        Ok(try!(NbtBlob::from_reader(src)))
     }
 }
 
@@ -389,11 +438,11 @@ mod tests {
     #[test]
     fn nbt_nonempty() {
         let mut nbt = NbtBlob::new("".to_string());
-        nbt.insert("name".to_string(), NbtValue::String("Herobrine".to_string()));
-        nbt.insert("health".to_string(), NbtValue::Byte(100));
-        nbt.insert("food".to_string(), NbtValue::Float(20.0));
-        nbt.insert("emeralds".to_string(), NbtValue::Short(12345));
-        nbt.insert("timestamp".to_string(), NbtValue::Int(1424778774));
+        nbt.insert("name".to_string(), NbtValue::String("Herobrine".to_string())).unwrap();
+        nbt.insert("health".to_string(), NbtValue::Byte(100)).unwrap();
+        nbt.insert("food".to_string(), NbtValue::Float(20.0)).unwrap();
+        nbt.insert("emeralds".to_string(), NbtValue::Short(12345)).unwrap();
+        nbt.insert("timestamp".to_string(), NbtValue::Int(1424778774)).unwrap();
 
         let bytes = vec![
             0x0a,
@@ -462,7 +511,7 @@ mod tests {
         let mut inner = HashMap::new();
         inner.insert("test".to_string(), NbtValue::Byte(123));
         let mut nbt = NbtBlob::new("".to_string());
-        nbt.insert("inner".to_string(), NbtValue::Compound(inner));
+        nbt.insert("inner".to_string(), NbtValue::Compound(inner)).unwrap();
 
         let bytes = vec![
             0x0a,
@@ -495,7 +544,7 @@ mod tests {
     #[test]
     fn nbt_empty_list() {
         let mut nbt = NbtBlob::new("".to_string());
-        nbt.insert("list".to_string(), NbtValue::List(Vec::new()));
+        nbt.insert("list".to_string(), NbtValue::List(Vec::new())).unwrap();
 
         let bytes = vec![
             0x0a,
@@ -526,7 +575,23 @@ mod tests {
     fn nbt_no_root() {
         let bytes = vec![0x00];
         // Will fail, because the root is not a compound.
-        assert!(NbtBlob::from_reader(&mut io::Cursor::new(bytes.as_slice())).is_err());
+        assert_eq!(NbtBlob::from_reader(&mut io::Cursor::new(bytes.as_slice())),
+                Err(NbtError::NoRootCompound));
+    }
+
+    #[test]
+    fn nbt_invalid_id() {
+        let bytes = vec![
+            0x0a,
+                0x00, 0x00,
+                0x0f, // No tag associated with 0x0f.
+                    0x00, 0x04,
+                    0x6c, 0x69, 0x73, 0x74,
+                    0x01,
+            0x00
+        ];
+        assert_eq!(NbtBlob::from_reader(&mut io::Cursor::new(bytes.as_slice())),
+                   Err(NbtError::InvalidTypeId(15)));
     }
 
     #[test]
@@ -536,7 +601,8 @@ mod tests {
         badlist.push(NbtValue::Byte(1));
         badlist.push(NbtValue::Short(1));
         // Will fail to insert, because the List is heterogeneous.
-        assert!(nbt.insert("list".to_string(), NbtValue::List(badlist)).is_none());
+        assert_eq!(nbt.insert("list".to_string(), NbtValue::List(badlist)),
+                   Err(NbtError::HeterogeneousList));
     }
 
     #[test]
@@ -551,11 +617,11 @@ mod tests {
     fn nbt_compression() {
         // Create a non-trivial NbtBlob.
         let mut nbt = NbtBlob::new("".to_string());
-        nbt.insert("name".to_string(), NbtValue::String("Herobrine".to_string()));
-        nbt.insert("health".to_string(), NbtValue::Byte(100));
-        nbt.insert("food".to_string(), NbtValue::Float(20.0));
-        nbt.insert("emeralds".to_string(), NbtValue::Short(12345));
-        nbt.insert("timestamp".to_string(), NbtValue::Int(1424778774));
+        nbt.insert("name".to_string(), NbtValue::String("Herobrine".to_string())).unwrap();
+        nbt.insert("health".to_string(), NbtValue::Byte(100)).unwrap();
+        nbt.insert("food".to_string(), NbtValue::Float(20.0)).unwrap();
+        nbt.insert("emeralds".to_string(), NbtValue::Short(12345)).unwrap();
+        nbt.insert("timestamp".to_string(), NbtValue::Int(1424778774)).unwrap();
 
         // Test zlib encoding/decoding.
         let mut zlib_dst = Vec::new();


### PR DESCRIPTION
This is a nice and idiomatic way to abstract over the underlying errors using `FromError`, and also allows better testing and more helpful errors for consumers of these types.
