### PR TITLE
Adds the canonical `bigtest.nbt` test and a few benchmarks for NBT files.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ name = "hematite_server"
 path = "server/main.rs"
 doc = false
 test = false
+bench = false
 
 [lib]
 name = "hematite_server"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,12 @@
 #![feature(core)]
+#![feature(fs)]
 #![feature(io)]
+#![feature(test)]
 
 extern crate byteorder;
 extern crate flate2;
 extern crate uuid;
+extern crate test;
 
 pub mod packet;
 pub mod types;

--- a/src/types/nbt.rs
+++ b/src/types/nbt.rs
@@ -432,6 +432,9 @@ mod tests {
 
     use std::collections::HashMap;
     use std::io;
+    use std::fs::File;
+
+    use test::Bencher;
 
     use packet::Protocol;
 
@@ -634,5 +637,31 @@ mod tests {
         nbt.write_gzip(&mut gzip_dst).unwrap();
         let gz_file = NbtBlob::from_gzip(&mut io::Cursor::new(gzip_dst)).unwrap();
         assert_eq!(&nbt, &gz_file);
+    }
+
+    #[test]
+    fn nbt_bigtest() {
+        let mut bigtest_file = File::open("tests/big1.nbt").unwrap();
+        let bigtest = NbtBlob::from_gzip(&mut bigtest_file).unwrap();
+        // This is a pretty indirect way of testing correctness.
+        assert_eq!(1544, bigtest.len());
+    }
+
+    #[bench]
+    fn nbt_bench_bigwrite(b: &mut Bencher) {
+        let mut file = File::open("tests/big1.nbt").unwrap();
+        let nbt = NbtBlob::from_gzip(&mut file).unwrap();
+        b.iter(|| {
+            nbt.write(&mut io::sink())
+        });
+    }
+
+    #[bench]
+    fn nbt_bench_smallwrite(b: &mut Bencher) {
+        let mut file = File::open("tests/small4.nbt").unwrap();
+        let nbt = NbtBlob::from_reader(&mut file).unwrap();
+        b.iter(|| {
+            nbt.write(&mut io::sink())
+        });
     }
 }


### PR DESCRIPTION
Benchmark results:

```
nbt_bench_bigwrite   ... bench:     11154 ns/iter (+/- 6415)
nbt_bench_smallwrite ... bench:       788 ns/iter (+/- 93)
```

This is a pretty good confirmation that the parser works. It might be worth trying against some packet samples, sample config files, and sample world saves in the future, though.

The magic number 1544 can be confirmed via

``` sh
$ gzip -l tests/big1.nbt
  compressed uncompressed  ratio uncompressed_name
         507         1544  67.2% tests/big1.nbt
```
