### PR TITLE
Creates a separate crate for NBT encoding/decoding.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,6 @@ path = "src/lib.rs"
 byteorder = "*"
 flate2 = "*"
 uuid = "*"
+
+[dependencies.hem-nbt]
+path = "hem-nbt"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ name = "hematite_server"
 path = "server/main.rs"
 doc = false
 test = false
+bench = false
 
 [lib]
 name = "hematite_server"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,5 +23,5 @@ byteorder = "*"
 flate2 = "*"
 uuid = "*"
 
-[dependencies.hem-nbt]
+[dependencies.hematite-nbt]
 path = "hem-nbt"

--- a/hem-nbt/Cargo.toml
+++ b/hem-nbt/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+
+name = "hem-nbt"
+version = "0.0.1"
+authors = [
+    "Fenhl <fenhl@fenhl.net>",
+    "Carlos Cobo <toqueteos@gmail.com>",
+    "Aaron Jacobs <atheriel@gmail.com>"
+]
+
+[lib]
+name = "hem-nbt"
+path = "lib.rs"
+
+[dependencies]
+byteorder = "*"
+flate2 = "*"

--- a/hem-nbt/Cargo.toml
+++ b/hem-nbt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 
-name = "hem-nbt"
+name = "hematite-nbt"
 version = "0.0.1"
 authors = [
     "Fenhl <fenhl@fenhl.net>",
@@ -9,7 +9,7 @@ authors = [
 ]
 
 [lib]
-name = "hem-nbt"
+name = "nbt"
 path = "lib.rs"
 
 [dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@
 extern crate byteorder;
 extern crate flate2;
 extern crate uuid;
+extern crate "hem-nbt" as nbt;
 extern crate test;
 
 pub mod packet;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,8 +5,8 @@
 
 extern crate byteorder;
 extern crate flate2;
+extern crate nbt;
 extern crate uuid;
-extern crate "hem-nbt" as nbt;
 extern crate test;
 
 pub mod packet;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,12 @@
 #![feature(core)]
+#![feature(fs)]
 #![feature(io)]
+#![feature(test)]
 
 extern crate byteorder;
 extern crate flate2;
 extern crate uuid;
+extern crate test;
 
 pub mod packet;
 pub mod types;

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -10,7 +10,7 @@ mod varnum;
 
 pub use self::arr::Arr;
 pub use self::chunk::{Chunk, ChunkColumn};
-pub use self::nbt::{NbtBlob, NbtError, NbtValue};
+pub use nbt::{NbtBlob, NbtError, NbtValue};
 pub use self::pos::BlockPos;
 pub use self::slot::Slot;
 pub use self::uuid::UuidString;

--- a/src/types/nbt.rs
+++ b/src/types/nbt.rs
@@ -1,0 +1,21 @@
+//! A protocol implementation for `NbtBlob`s.
+
+use std::io;
+use nbt::NbtBlob;
+use packet::Protocol;
+
+impl Protocol for NbtBlob {
+    type Clean = NbtBlob;
+
+    fn proto_len(value: &NbtBlob) -> usize {
+        value.len()
+    }
+
+    fn proto_encode(value: &NbtBlob, mut dst: &mut io::Write) -> io::Result<()> {
+        Ok(try!(value.write(dst)))
+    }
+
+    fn proto_decode(mut src: &mut io::Read) -> io::Result<NbtBlob> {
+        Ok(try!(NbtBlob::from_reader(src)))
+    }
+}

--- a/src/types/nbt.rs
+++ b/src/types/nbt.rs
@@ -432,6 +432,9 @@ mod tests {
 
     use std::collections::HashMap;
     use std::io;
+    use std::fs::File;
+
+    use test::Bencher;
 
     use packet::Protocol;
 
@@ -634,5 +637,31 @@ mod tests {
         nbt.write_gzip(&mut gzip_dst).unwrap();
         let gz_file = NbtBlob::from_gzip(&mut io::Cursor::new(gzip_dst)).unwrap();
         assert_eq!(&nbt, &gz_file);
+    }
+
+    #[test]
+    fn nbt_bigtest() {
+        let mut bigtest_file = File::open("tests/big1.nbt").unwrap();
+        let bigtest = NbtBlob::from_gzip(&mut bigtest_file).unwrap();
+        // This is a pretty indirect way of testing correctness.
+        assert_eq!(1544, bigtest.len());
+    }
+
+    #[bench]
+    fn nbt_bench_bigwrite(b: &mut Bencher) {
+        let mut file = File::open("tests/big1.nbt").unwrap();
+        let nbt = NbtBlob::from_gzip(&mut file).unwrap();
+        b.iter(|| {
+            nbt.write(&mut io::sink())
+        });
+    }
+
+    #[bench]
+    fn nbt_bench_smallwrite(b: &mut Bencher) {
+        let mut file = File::open("tests/small4.nbt").unwrap();
+        let nbt = NbtBlob::from_reader(&mut file).unwrap();
+        b.iter(|| {
+            nbt.write(&mut io::sink())
+        });
     }
 }


### PR DESCRIPTION
This PR supersedes #39.

A few people expressed interest in doing this, and it seemed like a nice way to compartmentalize a piece of the project others might find useful. I've called the crate "hem-nbt" for now, but suggestions are welcome.

Note that the crate is entirely local. It uses the `path` mechanism of cargo in the top-level package.

Thoughts?
