### PR TITLE
Follow-up work on ChatJson

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ path = "src/lib.rs"
 [dependencies]
 byteorder = "*"
 flate2 = "*"
+json_macros = "*"
 regex = "*"
 regex_macros = "*"
 rustc-serialize = "*"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 #![feature(core, plugin, step_by, test)]
 #![cfg_attr(test, deny(missing_docs, warnings))]
-#![plugin(regex_macros)]
+#![plugin(json_macros, regex_macros)]
 
 extern crate byteorder;
 extern crate flate2;

--- a/src/util.rs
+++ b/src/util.rs
@@ -50,7 +50,7 @@ impl<T> Join<char> for T where T: IntoIterator, <T as IntoIterator>::Item: AsRef
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Range<T> {
     pub start: Option<T>,
     pub end: Option<T>


### PR DESCRIPTION
- [x] Change `extra` field type to `ChatJson`
- [x] Decode `ChatJson` encoded as a JSON string
- [x] Decode `ChatJson` encoded as a JSON array
- [x] Apply syntactic sugar if `ChatJson` can be encoded as a JSON string
- [x] Handle all fields
  - [x] `"text"`
  - [x] `"translate"`
  - [x] `"with"`
  - [x] `"score"`
  - [x] `"selector"`
  - [x] `"extra"`
  - [x] `"bold"`
  - [x] `"italic"`
  - [x] `"underlined"`
  - [x] `"strikethrough"`
  - [x] `"obfuscated"`
  - [x] `"color"`
  - [x] `"clickEvent"`
  - [x] `"hoverEvent"`
  - [x] `"insertion"`
- [x] Error on unknown field
- [x] Reject additional fields in `"score"`, `"clickEvent"`, and `"hoverEvent"`
- [x] Improve the `InvalidFieldType` error by adding field name, expected type, and found type.
