### PR TITLE
Minor iterator-related code style improvements

### DIFF
--- a/src/packet.rs
+++ b/src/packet.rs
@@ -374,10 +374,10 @@ pub mod play {
                     try!(<bool as Protocol>::proto_encode(&this.sky_light_sent, dst));
                     let columns = this.chunk_meta.len() as i32;
                     try!(<Var<i32> as Protocol>::proto_encode(&columns, dst));
-                    for cm in this.chunk_meta.iter() {
+                    for cm in &this.chunk_meta {
                         try!(<ChunkMeta as Protocol>::proto_encode(cm, dst));
                     }
-                    for cd in this.chunk_data.iter() {
+                    for cd in &this.chunk_data {
                         let chunk_column = try!(cd.encode());
                         try!(dst.write_all(&chunk_column));
                     }
@@ -387,7 +387,7 @@ pub mod play {
                     let sky_light_sent = try!(<bool as Protocol>::proto_decode(src));
                     let columns = try!(<Var<i32> as Protocol>::proto_decode(src));
                     let mut chunk_meta = Vec::with_capacity(columns as usize);
-                    for cm in chunk_meta.iter_mut() {
+                    for cm in &mut chunk_meta {
                         *cm = try!(<ChunkMeta as Protocol>::proto_decode(src));
                     }
                     // Read all encoded ChunkColumns, buffer size starts at 4KB, probably will get bigger

--- a/src/types/arr.rs
+++ b/src/types/arr.rs
@@ -30,7 +30,7 @@ impl<L: Protocol, T: Protocol> Protocol for Arr<L, T> where L::Clean: NumCast {
 
     fn proto_decode(src: &mut Read) -> io::Result<Vec<T::Clean>> {
         let len = try!(try!(<L as Protocol>::proto_decode(src)).to_usize().ok_or(io::Error::new(io::ErrorKind::InvalidInput, "could not read length of vector from Array length type", None)));
-        <io::Result<Vec<T::Clean>> as FromIterator<_>>::from_iter((0..len).map(|_| <T as Protocol>::proto_decode(src)))
+        io::Result::from_iter((0..len).map(|_| <T as Protocol>::proto_decode(src)))
     }
 }
 

--- a/src/types/chat.rs
+++ b/src/types/chat.rs
@@ -172,7 +172,7 @@ impl ToJson for ChatJson {
             _ => unimplemented!()
         };
 
-        for format in self.formats.iter() {
+        for format in &self.formats {
             d.insert(format.to_string(), Json::Boolean(true));
         }
 

--- a/src/types/chunk.rs
+++ b/src/types/chunk.rs
@@ -28,15 +28,15 @@ impl ChunkColumn {
         use byteorder::{LittleEndian, WriteBytesExt};
 
         let mut dst: Cursor<Vec<u8>> = Cursor::new(Vec::new());
-        for chunk in self.chunks.iter() {
+        for chunk in &self.chunks {
             for x in chunk.blocks.iter() {
                 try!(dst.write_u16::<LittleEndian>(*x));
             }
         }
-        for chunk in self.chunks.iter() {
+        for chunk in &self.chunks {
             try!(dst.write_all(&chunk.block_light));
         }
-        for chunk in self.chunks.iter() {
+        for chunk in &self.chunks {
             match chunk.sky_light {
                 Some(xs) => try!(dst.write_all(&xs)),
                 None => {}
@@ -62,18 +62,18 @@ impl ChunkColumn {
             chunks: chunks,
             biomes: None
         };
-        for chunk in column.chunks.iter_mut() {
+        for chunk in &mut column.chunks {
             for x in chunk.blocks.iter_mut() {
                 *x = try!(<u16 as Protocol>::proto_decode(src));
             }
         }
-        for chunk in column.chunks.iter_mut() {
+        for chunk in &mut column.chunks {
             // We use this instead of read_exact because it's an array, Vec is useless here.
             for x in chunk.block_light.iter_mut() {
                 *x = try!(<u8 as Protocol>::proto_decode(src));
             }
         }
-        for chunk in column.chunks.iter_mut() {
+        for chunk in &mut column.chunks {
             // sky_light value varies by packet
             // - 0x21 ChunkData uses `sky_light = dimension == Dimension::Overworld`
             // - 0x26 ChunkDataBulk uses `sky_light = true`

--- a/src/types/entity_metadata.rs
+++ b/src/types/entity_metadata.rs
@@ -63,7 +63,7 @@ impl Protocol for EntityMetadata {
         fn key(k: u8, idx: u8) -> u8 {
             (k << 5 | idx & 0x1f) & 0xff
         }
-        for (idx, value) in value.dict.iter() {
+        for (idx, value) in &value.dict {
             match value {
                 &Entry::Byte(ref b) => {
                     try!(<u8 as Protocol>::proto_encode(&key(0, *idx), dst));

--- a/src/types/pos.rs
+++ b/src/types/pos.rs
@@ -52,7 +52,7 @@ impl<T: Protocol> Protocol for [T; 3] {
     }
 
     fn proto_encode(value: &[T::Clean; 3], dst: &mut Write) -> io::Result<()> {
-        for coord in value.iter() {
+        for coord in value {
             try!(<T as Protocol>::proto_encode(coord, dst));
         }
         Ok(())

--- a/src/types/varnum.rs
+++ b/src/types/varnum.rs
@@ -157,7 +157,7 @@ mod tests {
     #[test]
     fn varint_read() {
         let tests = varint_tests();
-        for test in tests.iter() {
+        for test in &tests {
             let mut r = io::Cursor::new(test.bytes.clone());
             let value = <Var<i32> as Protocol>::proto_decode(&mut r).unwrap();
             assert_eq!(test.value, value);
@@ -167,7 +167,7 @@ mod tests {
     #[test]
     fn varint_write() {
         let tests = varint_tests();
-        for test in tests.iter() {
+        for test in &tests {
             let mut w = Vec::new();
             <Var<i32> as Protocol>::proto_encode(&test.value, &mut w).unwrap();
             assert_eq!(&w, &test.bytes);
@@ -177,7 +177,7 @@ mod tests {
     #[test]
     fn varlong_read() {
         let tests = varlong_tests();
-        for test in tests.iter() {
+        for test in &tests {
             let mut r = io::Cursor::new(test.bytes.clone());
             let value = <Var<i64> as Protocol>::proto_decode(&mut r).unwrap();
             assert_eq!(test.value, value);
@@ -187,7 +187,7 @@ mod tests {
     #[test]
     fn varlong_write() {
         let tests = varlong_tests();
-        for test in tests.iter() {
+        for test in &tests {
             let mut w = Vec::new();
             <Var<i64> as Protocol>::proto_encode(&test.value, &mut w).unwrap();
             assert_eq!(&w, &test.bytes);


### PR DESCRIPTION
The `IntoIterator` trait allows using `&` and `&mut` instead of `.iter()` and `.iter_mut()` in most for loops. Unfortunately, many of the longer array types used in the `types::chunk` module don't implement `IntoIterator` yet, so I had to leave those alone.

Also, the `from_iter` call in `types::arr` looks less ugly now.
