### PR TITLE
Fix compile warnings and move some conversion methods to std::convert trait impls

### DIFF
--- a/hem-nbt/lib.rs
+++ b/hem-nbt/lib.rs
@@ -125,7 +125,7 @@ impl NbtValue {
     }
 
     /// A string representation of this tag.
-    fn to_string(&self) -> &str {
+    fn tag_name(&self) -> &str {
         match *self {
             NbtValue::Byte(_)      => "TAG_Byte",
             NbtValue::Short(_)     => "TAG_Short",
@@ -168,10 +168,10 @@ impl NbtValue {
 
     /// Writes the header (that is, the value's type ID and optionally a title)
     /// of this `NbtValue` to an `io::Write` destination.
-    pub fn write_header(&self, mut dst: &mut io::Write, title: &String) -> Result<(), NbtError> {
+    pub fn write_header(&self, mut dst: &mut io::Write, title: &str) -> Result<(), NbtError> {
         try!(dst.write_u8(self.id()));
         try!(dst.write_u16::<BigEndian>(title.len() as u16));
-        try!(dst.write_all(title.as_slice().as_bytes()));
+        try!(dst.write_all(title.as_bytes()));
         Ok(())
     }
 
@@ -192,7 +192,7 @@ impl NbtValue {
             },
             NbtValue::String(ref val) => {
                 try!(dst.write_u16::<BigEndian>(val.len() as u16));
-                try!(dst.write_all(val.as_slice().as_bytes()));
+                try!(dst.write_all(val.as_bytes()));
             },
             NbtValue::List(ref vals) => {
                 // This is a bit of a trick: if the list is empty, don't bother
@@ -268,7 +268,7 @@ impl NbtValue {
             },
             0x08 => { // String
                 let len = try!(src.read_u16::<BigEndian>()) as usize;
-                Ok(NbtValue::String(try!(read_utf8(src, len as usize))))
+                Ok(NbtValue::String(try!(read_utf8(src, len))))
             },
             0x09 => { // List
                 let id = try!(src.read_u8());
@@ -317,9 +317,9 @@ impl fmt::Display for NbtValue {
                 if v.len() == 0 {
                     write!(f, "zero entries")
                 } else {
-                    try!(write!(f, "{} entries of type {}\n{{\n", v.len(), v[0].to_string()));
+                    try!(write!(f, "{} entries of type {}\n{{\n", v.len(), v[0].tag_name()));
                     for tag in v {
-                        try!(write!(f, "{}(None): {}\n", tag.to_string(), tag));
+                        try!(write!(f, "{}(None): {}\n", tag.tag_name(), tag));
                     }
                     try!(write!(f, "}}"));
                     Ok(())
@@ -328,7 +328,7 @@ impl fmt::Display for NbtValue {
             NbtValue::Compound(ref v) => {
                 try!(write!(f, "{} entry(ies)\n{{\n", v.len()));
                 for (name, tag) in v {
-                    try!(write!(f, "{}(\"{}\"): {}\n", tag.to_string(), name, tag));
+                    try!(write!(f, "{}(\"{}\"): {}\n", tag.tag_name(), name, tag));
                 }
                 try!(write!(f, "}}"));
                 Ok(())
@@ -452,7 +452,7 @@ impl NbtBlob {
     /// The uncompressed length of this `NbtBlob`, in bytes.
     pub fn len(&self) -> usize {
         // tag + name + content
-        1 + 2 + self.title.as_slice().len() + self.content.len()
+        1 + 2 + self.title.len() + self.content.len()
     }
 }
 

--- a/server/main.rs
+++ b/server/main.rs
@@ -1,4 +1,4 @@
-extern crate "hematite_server" as hem;
+extern crate hematite_server as hem;
 
 use std::io;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,4 @@
-#![feature(core)]
-#![feature(io)]
-#![feature(std_misc)]
-#![feature(step_by)]
-#![feature(test)]
+#![feature(convert, core, io, std_misc, step_by, test)]
 
 extern crate byteorder;
 extern crate flate2;

--- a/src/proto/slp.rs
+++ b/src/proto/slp.rs
@@ -82,7 +82,7 @@ pub fn response(mut stream: &mut TcpStream) -> io::Result<()> {
             let mut file = try!(File::open(&Path::new("assets/favicon.png")));
             let mut contents = Vec::new();
             try!(file.read_to_end(&mut contents));
-            let favicon = contents.as_slice().to_base64(STANDARD);
+            let favicon = contents.to_base64(STANDARD);
             // FIXME(toqueteos): Micro-optimization? We could totally drop JSON
             // encoding and just replace player values (online & max) with format! all
             // other values are static.

--- a/src/types/chat.rs
+++ b/src/types/chat.rs
@@ -323,7 +323,7 @@ mod test {
 
     #[test]
     fn chat_plain() {
-        let msg = ChatJson::msg("Hello, world!".to_string());
+        let msg = ChatJson::from("Hello, world!");
         let blob = r#"{
             "text": "Hello, world!"
         }"#;
@@ -342,7 +342,7 @@ mod test {
 
     #[test]
     fn chat_with_events() {
-        let mut msg = ChatJson::msg("Hello, world!".to_string());
+        let mut msg = ChatJson::from("Hello, world!");
         msg.formats.insert(Format::Bold);
         msg.formats.insert(Format::Strikethrough);
         msg.color = Some(Color::Red);

--- a/src/types/chunk.rs
+++ b/src/types/chunk.rs
@@ -1,6 +1,7 @@
 //! MC Protocol Chunk data types.
 
 use std::fmt;
+use std::default::Default;
 use std::io::prelude::*;
 use std::io::{self, Cursor};
 
@@ -56,7 +57,7 @@ impl ChunkColumn {
         let mut chunks = Vec::new();
         // NOTE: vec![Chunk::empty(); num_chunks as usize] won't work
         for _ in 0..num_chunks {
-            chunks.push(Chunk::empty());
+            chunks.push(Chunk::default());
         }
         let mut column = ChunkColumn{
             chunks: chunks,
@@ -123,18 +124,21 @@ impl Chunk {
         };
         8192 + 2048 + sky
     }
-    pub fn empty() -> Chunk {
-        Chunk {
-            blocks: [0u16; 4096],
-            block_light: [0u8; 2048],
-            sky_light: None
-        }
-    }
     pub fn new(block: u16, light: u8) -> Chunk {
         Chunk {
             blocks: [block; 4096],
             block_light: [light; 2048],
             sky_light: Some([light; 2048])
+        }
+    }
+}
+
+impl Default for Chunk {
+    fn default() -> Chunk {
+        Chunk {
+            blocks: [0u16; 4096],
+            block_light: [0u8; 2048],
+            sky_light: None
         }
     }
 }

--- a/src/types/consts.rs
+++ b/src/types/consts.rs
@@ -6,6 +6,8 @@ use std::num::FromPrimitive;
 
 use packet::Protocol;
 
+use rustc_serialize::json::{Json, ToJson};
+
 macro_rules! enum_protocol_impl {
     ($name:ty, $repr:ty, $dec_repr:ident) => {
         impl Protocol for $name {
@@ -61,30 +63,32 @@ pub enum Color {
     White       = 0xf
 }
 
-impl Color {
-    pub fn to_string(&self) -> String {
-        match self {
-            &Color::Black => "black".to_string(),
-            &Color::DarkBlue => "dark_blue".to_string(),
-            &Color::DarkGreen => "dark_green".to_string(),
-            &Color::DarkCyan => "dark_aqua".to_string(),
-            &Color::DarkRed => "dark_red".to_string(),
-            &Color::Purple => "dark_purple".to_string(),
-            &Color::Gold => "gold".to_string(),
-            &Color::Gray => "gray".to_string(),
-            &Color::DarkGray => "dark_gray".to_string(),
-            &Color::Blue => "blue".to_string(),
-            &Color::BrightGreen => "green".to_string(),
-            &Color::Cyan => "aqua".to_string(),
-            &Color::Red => "red".to_string(),
-            &Color::Pink => "light_purple".to_string(),
-            &Color::Yellow => "yellow".to_string(),
-            &Color::White => "white".to_string()
+impl AsRef<str> for Color {
+    fn as_ref(&self) -> &str {
+        match *self {
+            Color::Black => "black",
+            Color::DarkBlue => "dark_blue",
+            Color::DarkGreen => "dark_green",
+            Color::DarkCyan => "dark_aqua",
+            Color::DarkRed => "dark_red",
+            Color::Purple => "dark_purple",
+            Color::Gold => "gold",
+            Color::Gray => "gray",
+            Color::DarkGray => "dark_gray",
+            Color::Blue => "blue",
+            Color::BrightGreen => "green",
+            Color::Cyan => "aqua",
+            Color::Red => "red",
+            Color::Pink => "light_purple",
+            Color::Yellow => "yellow",
+            Color::White => "white"
         }
     }
+}
 
-    pub fn from_string(string: &String) -> Option<Color> {
-        match string.as_slice() {
+impl<'a> From<&'a str> for Option<Color> {
+    fn from(string: &str) -> Option<Color> {
+        match string {
             "black"        => Some(Color::Black),
             "dark_blue"    => Some(Color::DarkBlue),
             "dark_green"   => Some(Color::DarkGreen),
@@ -103,5 +107,11 @@ impl Color {
             "white"        => Some(Color::White),
             _              => None
         }
+    }
+}
+
+impl ToJson for Color {
+    fn to_json(&self) -> Json {
+        self.as_ref().to_json()
     }
 }

--- a/src/types/pos.rs
+++ b/src/types/pos.rs
@@ -3,7 +3,6 @@
 use std::io;
 use std::io::prelude::*;
 use std::iter::AdditiveIterator;
-use std::num::Int;
 
 use packet::Protocol;
 


### PR DESCRIPTION
Leaving this open for discussion since  `std::convert` seems to be controversial.

cc @eddyb
