### PR TITLE
Update to latest Rust

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(convert, core, io, std_misc, step_by, test)]
+#![feature(core, step_by, test)]
 
 extern crate byteorder;
 extern crate flate2;

--- a/src/proto/properties.rs
+++ b/src/proto/properties.rs
@@ -12,10 +12,10 @@ macro_rules! parse {
         $value.to_string()
     };
     ($value:ident, bool) => {
-        try!($value.parse().map_err(|_: ParseBoolError| io::Error::new(io::ErrorKind::InvalidInput, "invalid bool value", None)))
+        try!($value.parse().map_err(|_: ParseBoolError| io::Error::new(io::ErrorKind::InvalidInput, "invalid bool value")))
     };
     ($value:ident, i32) => {
-        try!($value.parse().map_err(|_: ParseIntError| io::Error::new(io::ErrorKind::InvalidInput, "invalid i32 value", None)))
+        try!($value.parse().map_err(|_: ParseIntError| io::Error::new(io::ErrorKind::InvalidInput, "invalid i32 value")))
     }
 }
 

--- a/src/proto/slp.rs
+++ b/src/proto/slp.rs
@@ -63,7 +63,7 @@ impl Protocol for Response {
     fn proto_decode(src: &mut Read) -> io::Result<Response> {
         let s = try!(<String as Protocol>::proto_decode(src));
         println!("Response proto_decode {}", s);
-        json::decode(&s).map_err(|_| io::Error::new(InvalidInput, "found invalid JSON", None))
+        json::decode(&s).map_err(|_| io::Error::new(InvalidInput, "found invalid JSON"))
     }
 }
 
@@ -104,7 +104,7 @@ pub fn response(mut stream: &mut TcpStream) -> io::Result<()> {
             try!(StatusResponse { response: resp }.write(stream));
             Ok(())
         }
-        wrong_packet => Err(io::Error::new(InvalidInput, "invalid packet read", Some(format!("expecting C->S StatusRequest packet, got {:?}", wrong_packet))))
+        wrong_packet => Err(io::Error::new(InvalidInput, &format!("Invalid packet read, expecting C->S StatusRequest packet, got {:?}", wrong_packet)[..]))
     }
 }
 
@@ -120,7 +120,7 @@ pub fn pong(mut stream: &mut TcpStream) -> io::Result<()> {
             try!(Pong { time: ping.time }.write(stream));
             Ok(())
         }
-        wrong_packet => Err(io::Error::new(InvalidInput, "invalid packet read", Some(format!("expecting C->S Ping packet, got {:?}", wrong_packet))))
+        wrong_packet => Err(io::Error::new(InvalidInput, &format!("Invalid packet read, expecting C->S Ping packet, got {:?}", wrong_packet)[..]))
     }
 }
 
@@ -135,7 +135,7 @@ pub fn request(mut stream: &mut TcpStream) -> io::Result<Response> {
     // S->C: Status Response packet
     match try!(Packet::read(stream)) {
         StatusResponse(resp) => Ok(resp.response),
-        wrong_packet => Err(io::Error::new(InvalidInput, "invalid packet read", Some(format!("expecting S->C StatusResponse packet, got {:?}", wrong_packet))))
+        wrong_packet => Err(io::Error::new(InvalidInput, &format!("Invalid packet read, expecting S->C StatusResponse packet, got {:?}", wrong_packet)[..]))
     }
 }
 
@@ -155,7 +155,7 @@ pub fn ping(mut stream: &mut TcpStream) -> io::Result<i64> {
             let elapsed = end.sub(start).num_milliseconds();
             Ok(elapsed)
         }
-        wrong_packet => Err(io::Error::new(InvalidInput, "invalid packet read", Some(format!("expecting S->C Pong packet, got {:?}", wrong_packet))))
+        wrong_packet => Err(io::Error::new(InvalidInput, &format!("Invalid packet read, expecting S->C Pong packet, got {:?}", wrong_packet)[..]))
     }
 }
 

--- a/src/types/arr.rs
+++ b/src/types/arr.rs
@@ -20,7 +20,7 @@ impl<L: Protocol, T: Protocol> Protocol for Arr<L, T> where L::Clean: NumCast {
     }
 
     fn proto_encode(value: &Vec<T::Clean>, dst: &mut Write) -> io::Result<()> {
-        let len = try!(<L::Clean as NumCast>::from(value.len()).ok_or(io::Error::new(io::ErrorKind::InvalidInput, "could not convert length of vector to Array length type", None)));
+        let len = try!(<L::Clean as NumCast>::from(value.len()).ok_or(io::Error::new(io::ErrorKind::InvalidInput, "could not convert length of vector to Array length type")));
         try!(<L as Protocol>::proto_encode(&len, dst));
         for elt in value {
             try!(<T as Protocol>::proto_encode(elt, dst));
@@ -29,7 +29,7 @@ impl<L: Protocol, T: Protocol> Protocol for Arr<L, T> where L::Clean: NumCast {
     }
 
     fn proto_decode(src: &mut Read) -> io::Result<Vec<T::Clean>> {
-        let len = try!(try!(<L as Protocol>::proto_decode(src)).to_usize().ok_or(io::Error::new(io::ErrorKind::InvalidInput, "could not read length of vector from Array length type", None)));
+        let len = try!(try!(<L as Protocol>::proto_decode(src)).to_usize().ok_or(io::Error::new(io::ErrorKind::InvalidInput, "could not read length of vector from Array length type")));
         io::Result::from_iter((0..len).map(|_| <T as Protocol>::proto_decode(src)))
     }
 }

--- a/src/types/chunk.rs
+++ b/src/types/chunk.rs
@@ -49,10 +49,7 @@ impl ChunkColumn {
         }
         Ok(dst.into_inner())
     }
-    //
     pub fn decode(mut src: &mut Read, mask: u16, continuous: bool, sky_light: bool) -> io::Result<ChunkColumn> {
-        use std::num::Int;
-
         let num_chunks = mask.count_ones();
         let mut chunks = Vec::new();
         // NOTE: vec![Chunk::empty(); num_chunks as usize] won't work

--- a/src/types/consts.rs
+++ b/src/types/consts.rs
@@ -3,6 +3,7 @@
 use std::io::prelude::*;
 use std::io;
 use std::num::FromPrimitive;
+use std::str::FromStr;
 
 use packet::Protocol;
 
@@ -26,7 +27,7 @@ macro_rules! enum_protocol_impl {
                 let value = try!(<$repr as Protocol>::proto_decode(src));
                 match FromPrimitive::$dec_repr(value) {
                     Some(x) => Ok(x),
-                    None => Err(io::Error::new(io::ErrorKind::InvalidInput, "invalid enum", None))
+                    None => Err(io::Error::new(io::ErrorKind::InvalidInput, "invalid enum"))
                 }
             }
         }
@@ -86,26 +87,28 @@ impl AsRef<str> for Color {
     }
 }
 
-impl<'a> From<&'a str> for Option<Color> {
-    fn from(string: &str) -> Option<Color> {
+impl FromStr for Color {
+    type Err = ();
+
+    fn from_str(string: &str) -> Result<Color, ()> {
         match string {
-            "black"        => Some(Color::Black),
-            "dark_blue"    => Some(Color::DarkBlue),
-            "dark_green"   => Some(Color::DarkGreen),
-            "dark_aqua"    => Some(Color::DarkCyan),
-            "dark_red"     => Some(Color::DarkRed),
-            "dark_purple"  => Some(Color::Purple),
-            "gold"         => Some(Color::Gold),
-            "gray"         => Some(Color::Gray),
-            "dark_gray"    => Some(Color::DarkGray),
-            "blue"         => Some(Color::Blue),
-            "green"        => Some(Color::BrightGreen),
-            "aqua"         => Some(Color::Cyan),
-            "red"          => Some(Color::Red),
-            "light_purple" => Some(Color::Pink),
-            "yellow"       => Some(Color::Yellow),
-            "white"        => Some(Color::White),
-            _              => None
+            "black"        => Ok(Color::Black),
+            "dark_blue"    => Ok(Color::DarkBlue),
+            "dark_green"   => Ok(Color::DarkGreen),
+            "dark_aqua"    => Ok(Color::DarkCyan),
+            "dark_red"     => Ok(Color::DarkRed),
+            "dark_purple"  => Ok(Color::Purple),
+            "gold"         => Ok(Color::Gold),
+            "gray"         => Ok(Color::Gray),
+            "dark_gray"    => Ok(Color::DarkGray),
+            "blue"         => Ok(Color::Blue),
+            "green"        => Ok(Color::BrightGreen),
+            "aqua"         => Ok(Color::Cyan),
+            "red"          => Ok(Color::Red),
+            "light_purple" => Ok(Color::Pink),
+            "yellow"       => Ok(Color::Yellow),
+            "white"        => Ok(Color::White),
+            _              => Err(())
         }
     }
 }

--- a/src/types/entity_metadata.rs
+++ b/src/types/entity_metadata.rs
@@ -121,7 +121,7 @@ impl Protocol for EntityMetadata {
                 6 => Entry::Int3(try!(<[i32; 3] as Protocol>::proto_decode(src))),
                 7 => Entry::Float3(try!(<[f32; 3] as Protocol>::proto_decode(src))),
                 ty => {
-                    return Err(io::Error::new(io::ErrorKind::InvalidInput, "unknown type", Some(format!("unknown type {:x}", ty))));
+                    return Err(io::Error::new(io::ErrorKind::InvalidInput, &format!("Unknown type {:x}", ty)[..]));
                 }
             };
             dict.insert(idx, value);

--- a/src/types/pos.rs
+++ b/src/types/pos.rs
@@ -13,7 +13,7 @@ pub struct BlockPos;
 macro_rules! bounds_check {
     ($name:expr, $value:expr, $size:expr) => {
         if $value < -(1 << $size) || $value >= (1 << $size) {
-            return Err(io::Error::new(io::ErrorKind::InvalidInput, "coordinate out of bounds", Some(format!("expected {} to {}, found {} for {} coord", -(1 << $size), (1 << $size) - 1, $value, $name))));
+            return Err(io::Error::new(io::ErrorKind::InvalidInput, &format!("Coordinate out of bounds: expected {} to {}, found {} for {} coord", -(1 << $size), (1 << $size) - 1, $value, $name)[..]));
         }
     }
 }

--- a/src/types/string.rs
+++ b/src/types/string.rs
@@ -27,6 +27,6 @@ impl Protocol for String {
     fn proto_decode(mut src: &mut Read) -> io::Result<String> {
         let len: i32 = try!(<Var<i32> as Protocol>::proto_decode(src));
         let s = try!(src.read_exact(len as usize));
-        String::from_utf8(s).map_err(|utf8_err| io::Error::new(io::ErrorKind::InvalidInput, "invalid String value", Some(format!("UTF-8 error: {}", utf8_err.utf8_error().description()))))
+        String::from_utf8(s).map_err(|utf8_err| io::Error::new(io::ErrorKind::InvalidInput, &format!("UTF-8 error: {}", utf8_err.utf8_error().description())[..]))
     }
 }

--- a/src/types/uuid.rs
+++ b/src/types/uuid.rs
@@ -21,7 +21,7 @@ impl Protocol for Uuid {
     /// Reads 16 bytes from `src` and returns a `Uuid`
     fn proto_decode(mut src: &mut Read) -> io::Result<Uuid> {
         let v = try!(src.read_exact(16));
-        Uuid::from_bytes(&v).ok_or(io::Error::new(io::ErrorKind::InvalidInput, "invalid UUID value", Some(format!("value {:?} can't be used to create UUID", v))))
+        Uuid::from_bytes(&v).ok_or(io::Error::new(io::ErrorKind::InvalidInput, &format!("Invalid UUID value: {:?} can't be used to create UUID", v)[..]))
     }
 }
 
@@ -42,10 +42,10 @@ impl Protocol for UuidString {
         // Unfortunately we can't implement `impl FromError<ParseError> for io::Error`
         let s = try!(<String as Protocol>::proto_decode(src));
         Uuid::from_str(&s).map_err(|err| match err {
-            ParseError::InvalidLength(length) => io::Error::new(InvalidInput, "invalid length", Some(format!("length = {}", length))),
-            ParseError::InvalidCharacter(_, _) => io::Error::new(InvalidInput, "invalid character", None),
-            ParseError::InvalidGroups(_) => io::Error::new(InvalidInput, "invalid groups", None),
-            ParseError::InvalidGroupLength(_, _, _) => io::Error::new(InvalidInput, "invalid group length", None),
+            ParseError::InvalidLength(length) => io::Error::new(InvalidInput, &format!("Invalid length: {}", length)[..]),
+            ParseError::InvalidCharacter(_, _) => io::Error::new(InvalidInput, "invalid character"),
+            ParseError::InvalidGroups(_) => io::Error::new(InvalidInput, "invalid groups"),
+            ParseError::InvalidGroupLength(_, _, _) => io::Error::new(InvalidInput, "invalid group length"),
         })
     }
 }

--- a/src/types/varnum.rs
+++ b/src/types/varnum.rs
@@ -53,7 +53,7 @@ impl Protocol for Var<i32> {
         }
 
         // The number is too large to represent in a 32-bit value.
-        Err(io::Error::new(io::ErrorKind::InvalidInput, "VarInt too big", None))
+        Err(io::Error::new(io::ErrorKind::InvalidInput, "VarInt too big"))
     }
 }
 
@@ -99,7 +99,7 @@ impl Protocol for Var<i64> {
         }
 
         // The number is too large to represent in a 64-bit value.
-        Err(io::Error::new(io::ErrorKind::InvalidInput, "VarLong too big", None))
+        Err(io::Error::new(io::ErrorKind::InvalidInput, "VarLong too big"))
     }
 }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -10,7 +10,7 @@ pub trait ReadExactExt: Read {
         let mut n_read = 0usize;
         while n_read < buf.len() {
             match try!(self.read(&mut buf[n_read..])) {
-                0 => { return Err(io::Error::new(io::ErrorKind::InvalidInput, "unexpected EOF", None)); }
+                0 => { return Err(io::Error::new(io::ErrorKind::InvalidInput, "unexpected EOF")); }
                 n => n_read += n
             }
         }


### PR DESCRIPTION
Mostly changes to `io::Error::new`, but I also had to revert two of the `std::convert::From` impls introduced in #66 because the trait implementation restrictions have yet again been increased:
-   `Result<ChatJson, ChatJsonError>::from(Json)` is now `ChatJson::from_json` again
-   `Option<Color>::from(&str)` (which was originally `Color::from_string`) is now a [`FromStr`](http://doc.rust-lang.org/std/str/trait.FromStr.html) implementation
