### PR TITLE
Deny warnings and missing docs in cfg(test)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 #![feature(core, step_by, test)]
+#![cfg_attr(test, deny(missing_docs, warnings))]
 
 extern crate byteorder;
 extern crate flate2;


### PR DESCRIPTION
This way, `cargo test` will find more errors without interfering with regular and release builds.

It currently fails because of an unused enum variant in `ChatJsonError`; this is fixed in #57.
