### PR TITLE
Forbid unused_variables lint

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 #![feature(custom_derive, iter_arith, plugin, step_by, test)]
 #![cfg_attr(test, deny(missing_docs, warnings))]
 #![forbid(unused_variables)]
-#![plugin(json_macros, num_macros, regex_macros)]
+#![plugin(json_macros, num_macros)]
 
 extern crate byteorder;
 extern crate flate2;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 #![feature(custom_derive, iter_arith, plugin, step_by, test)]
 #![cfg_attr(test, deny(missing_docs, warnings))]
+#![forbid(unused_variables)]
 #![plugin(json_macros, num_macros, regex_macros)]
 
 extern crate byteorder;

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -109,8 +109,7 @@ macro_rules! impl_protocol {
         impl Protocol for $name {
             type Clean = Self;
 
-            #[allow(unused_variables)]
-            fn proto_len(value: &$name) -> usize { 1 }
+            fn proto_len(_: &$name) -> usize { 1 }
 
             fn proto_encode(value: &$name, mut dst: &mut Write) -> io::Result<()> {
                 try!(dst.$enc_name(*value));
@@ -126,8 +125,7 @@ macro_rules! impl_protocol {
         impl Protocol for $name {
             type Clean = Self;
 
-            #[allow(unused_variables)]
-            fn proto_len(value: &$name) -> usize { $len }
+            fn proto_len(_: &$name) -> usize { $len }
 
             fn proto_encode(value: &$name, mut dst: &mut Write) -> io::Result<()> {
                 try!(dst.$enc_name::<BigEndian>(*value));
@@ -218,8 +216,7 @@ impl_protocol!(f64, 8, write_f64, read_f64);
 impl Protocol for bool {
     type Clean = bool;
 
-    #[allow(unused_variables)]
-    fn proto_len(value: &bool) -> usize { 1 }
+    fn proto_len(_: &bool) -> usize { 1 }
 
     fn proto_encode(value: &bool, mut dst: &mut Write) -> io::Result<()> {
         try!(dst.write_u8(if *value { 1 } else { 0 }));

--- a/src/types/consts.rs
+++ b/src/types/consts.rs
@@ -15,7 +15,6 @@ macro_rules! enum_protocol_impl {
         impl Protocol for $name {
             type Clean = $name;
 
-            #[allow(unused_variables)]
             fn proto_len(value: &$name) -> usize { <$repr as Protocol>::proto_len(&(*value as $repr)) }
 
             fn proto_encode(value: &$name, mut dst: &mut Write) -> io::Result<()> {

--- a/src/types/pos.rs
+++ b/src/types/pos.rs
@@ -20,8 +20,7 @@ macro_rules! bounds_check {
 impl Protocol for BlockPos {
     type Clean = [i32; 3];
 
-    #[allow(unused_variables)]
-    fn proto_len(value: &[i32; 3]) -> usize { 8 }
+    fn proto_len(_: &[i32; 3]) -> usize { 8 }
 
     fn proto_encode(value: &[i32; 3], mut dst: &mut Write) -> io::Result<()> {
         let x = value[0].clone();

--- a/src/types/selector.rs
+++ b/src/types/selector.rs
@@ -1,6 +1,9 @@
 use std::collections::HashMap;
 use std::num::{ParseFloatError, ParseIntError};
 use std::str::FromStr;
+
+use regex::Regex;
+
 use util::{Join, Range};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -130,7 +133,7 @@ impl FromStr for EntitySelector {
     type Err = Error;
 
     fn from_str(s: &str) -> Result<EntitySelector, Error> {
-        if let Some(captures) = regex!(r"^@(.)(\[(.*)\])?$").captures(s) {
+        if let Some(captures) = Regex::new(r"^@(.)(\[(.*)\])?$").unwrap().captures(s) {
             let mut result = match captures.at(1).unwrap() {
                 "a" => EntitySelector::all(),
                 "e" => EntitySelector::default(),
@@ -142,7 +145,7 @@ impl FromStr for EntitySelector {
                 let mut positional_seen = 0u8; // number of positional arguments (x, y, z, r) encountered
                 let mut named_seen = false; // whether a named argument has been encountered
                 for arg in args.split(',') {
-                    if let Some(captures) = regex!("^(.*)=(.*)$").captures(arg) {
+                    if let Some(captures) = Regex::new("^(.*)=(.*)$").unwrap().captures(arg) {
                         // named argument
                         let key = captures.at(1).unwrap();
                         let value = captures.at(2).unwrap();
@@ -167,10 +170,10 @@ impl FromStr for EntitySelector {
                             "rym" => { result.yaw.start = Some(try!(f32::from_str(value))); }
                             "type" => { result.entity_type = Attr::from(value) }
                             k => {
-                                if let Some(captures) = regex!("score_([A-Za-z]+)").captures(k) {
+                                if let Some(captures) = Regex::new("score_([A-Za-z]+)").unwrap().captures(k) {
                                     let objective = captures.at(1).unwrap();
                                     result.scores.entry(objective.to_string()).or_insert(Range::from(..)).end = Some(try!(i32::from_str(value)));
-                                } else if let Some(captures) = regex!("score_([A-Za-z]+)_min").captures(k) {
+                                } else if let Some(captures) = Regex::new("score_([A-Za-z]+)_min").unwrap().captures(k) {
                                     let objective = captures.at(1).unwrap();
                                     result.scores.entry(objective.to_string()).or_insert(Range::from(..)).start = Some(try!(i32::from_str(value)));
                                 } else {
@@ -184,7 +187,7 @@ impl FromStr for EntitySelector {
                         if named_seen {
                             return Err(Error::PositionalAfterNamed);
                         }
-                        if regex!("^ *$").is_match(arg) {
+                        if Regex::new("^ *$").unwrap().is_match(arg) {
                             // empty, keep default
                         } else {
                             match positional_seen {

--- a/src/types/varnum.rs
+++ b/src/types/varnum.rs
@@ -40,7 +40,6 @@ impl Protocol for Var<i32> {
     }
 
     /// Reads up to 5 bytes from `src`, until a valid `Var<i32>` is found.
-    #[allow(unused_variables)]
     fn proto_decode(mut src: &mut Read) -> io::Result<i32> {
         let mut x = 0i32;
 
@@ -85,13 +84,12 @@ impl Protocol for Var<i64> {
         }
     }
 
-    /// Reads up to 10 bytes from `dst`, until a valid `Var<i64>` is found.
-    #[allow(unused_variables)]
-    fn proto_decode(mut dst: &mut Read) -> io::Result<i64> {
+    /// Reads up to 10 bytes from `src`, until a valid `Var<i64>` is found.
+    fn proto_decode(mut src: &mut Read) -> io::Result<i64> {
         let mut x = 0i64;
 
         for shift in (0..64).step_by(7) {
-            let b = try!(dst.read_u8()) as i64;
+            let b = try!(src.read_u8()) as i64;
             x |= (b & 0x7F) << shift;
             if (b & 0x80) == 0 {
                 return Ok(x);


### PR DESCRIPTION
Instead of using `#[allow(unused_variables)]`, we can simply mark function parameters as unused using the `_` notation. This PR enforces this using a crate-level `#![forbid(unused_variables)]`, and changes existing occurrences accordingly.
