### PR TITLE
Update to latest Rust

### DIFF
--- a/src/types/chunk.rs
+++ b/src/types/chunk.rs
@@ -106,7 +106,6 @@ impl fmt::Debug for ChunkColumn {
 /// Chunk is a group of 16x16x16 blocks.
 ///
 /// `block_light`, `sky_light` are nibble arrays (4bit values)
-#[derive(Copy)]
 pub struct Chunk {
     pub blocks: [u16; 4096],
     pub block_light: [u8; 2048],

--- a/src/types/consts.rs
+++ b/src/types/consts.rs
@@ -37,14 +37,14 @@ macro_rules! enum_protocol_impl {
 enum_protocol_impl!(Dimension, i8, from_i8);
 
 #[repr(i8)]
-#[derive(Copy, Debug, FromPrimitive, PartialEq)]
+#[derive(Clone, Copy, Debug, FromPrimitive, PartialEq)]
 pub enum Dimension {
     Nether = -1,
     Overworld = 0,
     End = 1
 }
 
-#[derive(Copy, Debug, Clone, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Color {
     Black       = 0x0,
     DarkBlue    = 0x1,


### PR DESCRIPTION
This removes the `Copy` impl from `Chunk`, which appears to be unused anyway. It can be manually implemented if required, or we can wait until large arrays are `Copy` and reintroduce the derived impl then.
