### PR TITLE
Update to latest Rust

### DIFF
--- a/hem-nbt/lib.rs
+++ b/hem-nbt/lib.rs
@@ -10,7 +10,6 @@ use std::collections::HashMap;
 use std::fmt;
 use std::io;
 use std::io::ErrorKind::InvalidInput;
-use std::iter::AdditiveIterator;
 use std::ops::Index;
 use std::string;
 
@@ -151,13 +150,13 @@ impl NbtValue {
             NbtValue::String(ref val)    => 2 + val.len(), // size + bytes
             NbtValue::List(ref vals)     => {
                 // tag + size + payload for each element
-                5 + vals.iter().map(|x| x.len()).sum()
+                5 + vals.iter().map(|x| x.len()).sum::<usize>()
             },
             NbtValue::Compound(ref vals) => {
                 vals.iter().map(|(name, nbt)| {
                     // tag + name + payload for each entry
                     3 + name.len() + nbt.len()
-                }).sum() + 1 // + u8 for the Tag_End
+                }).sum::<usize>() + 1 // + u8 for the Tag_End
             },
             NbtValue::IntArray(ref val)  => 4 + 4 * val.len(),
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ extern crate byteorder;
 extern crate flate2;
 extern crate nbt;
 extern crate regex;
+extern crate regex_macros;
 extern crate rustc_serialize;
 extern crate test;
 extern crate time;

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -360,13 +360,11 @@ pub mod play {
             impl Protocol for ChunkDataBulk {
                 type Clean = Self;
                 fn proto_len(this: &Self) -> usize {
-                    use std::iter::AdditiveIterator;
-
                     let columns = this.chunk_meta.len() as i32;
                     1 // sky_light_sent(bool) len is constant
                     + <Var<i32> as Protocol>::proto_len(&columns)
-                    + this.chunk_meta.iter().map(|cm| <ChunkMeta as Protocol>::proto_len(cm)).sum()
-                    + this.chunk_data.iter().map(|cd| cd.len()).sum()
+                    + this.chunk_meta.iter().map(<ChunkMeta as Protocol>::proto_len).sum::<usize>()
+                    + this.chunk_data.iter().map(|cd| cd.len()).sum::<usize>()
                 }
                 fn proto_encode(this: &Self, mut dst: &mut Write) -> io::Result<()> {
                     try!(<bool as Protocol>::proto_encode(&this.sky_light_sent, dst));

--- a/src/types/arr.rs
+++ b/src/types/arr.rs
@@ -2,7 +2,7 @@
 
 use std::io;
 use std::io::prelude::*;
-use std::iter::{ AdditiveIterator, FromIterator };
+use std::iter::FromIterator;
 use std::marker::PhantomData;
 use std::num::{ NumCast, ToPrimitive };
 
@@ -15,7 +15,7 @@ impl<L: Protocol, T: Protocol> Protocol for Arr<L, T> where L::Clean: NumCast {
 
     fn proto_len(value: &Vec<T::Clean>) -> usize {
         let len_len = <L as Protocol>::proto_len(&(<<L as Protocol>::Clean as NumCast>::from(value.len()).unwrap()));
-        let len_values = value.iter().map(|elt| <T as Protocol>::proto_len(elt)).sum();
+        let len_values = value.iter().map(<T as Protocol>::proto_len).sum::<usize>();
         len_len + len_values
     }
 

--- a/src/types/chunk.rs
+++ b/src/types/chunk.rs
@@ -16,9 +16,7 @@ pub struct ChunkColumn {
 
 impl ChunkColumn {
     pub fn len(&self) -> usize {
-        use std::iter::AdditiveIterator;
-
-        let chunks = self.chunks.iter().map(|x| x.len()).sum();
+        let chunks = self.chunks.iter().map(|x| x.len()).sum::<usize>();
         let biomes = match self.biomes {
             Some(_) => 256,
             None => 0

--- a/src/types/entity_metadata.rs
+++ b/src/types/entity_metadata.rs
@@ -43,8 +43,6 @@ impl EntityMetadata {
 impl Protocol for EntityMetadata {
     type Clean = EntityMetadata;
     fn proto_len(value: &EntityMetadata) -> usize {
-        use std::iter::AdditiveIterator;
-
         fn entry_len(value: &Entry) -> usize {
             match value {
                 &Entry::Byte(_) => 1,
@@ -57,7 +55,7 @@ impl Protocol for EntityMetadata {
                 | &Entry::Float3(_) => 12,
             }
         }
-        value.dict.values().map(|v| entry_len(v)).sum()
+        value.dict.values().map(entry_len).sum()
     }
     fn proto_encode(value: &EntityMetadata, dst: &mut Write) -> io::Result<()> {
         fn key(k: u8, idx: u8) -> u8 {

--- a/src/types/pos.rs
+++ b/src/types/pos.rs
@@ -2,7 +2,6 @@
 
 use std::io;
 use std::io::prelude::*;
-use std::iter::AdditiveIterator;
 
 use packet::Protocol;
 


### PR DESCRIPTION
Migrates usages of `AdditiveIterator` to the generic `sum` method on `Iterator`. Also unrelatedly simplifies some closures of the form `|x| foo(x)` to the equivalent `foo`. Tests are failing because of rust-lang/cargo#1512.
