### PR TITLE
Update to latest Rust nightly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ byteorder = "*"
 flate2 = "*"
 json_macros = "*"
 num = "*"
-num-macros = "*"
+#num-macros = "*"
 regex = "*"
 regex_macros = "*"
 rustc-serialize = "*"
@@ -32,3 +32,6 @@ uuid = "*"
 
 [dependencies.hematite-nbt]
 path = "hem-nbt"
+
+[dependencies.num-macros]
+git = "https://github.com/rust-lang/num.git" # crates.io version is outdated


### PR DESCRIPTION
This updates the num-macros dependency to a version that compiles on nightly, but is not on [crates.io](https://crates.io/) yet.
