### PR TITLE
Tell Travis CI to use Rust nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: rust
+rust: nightly
 notifications:
   irc: "irc.mozilla.org#hematite"
 script:


### PR DESCRIPTION
This is to reflect the fact that the crate currently does not build on stable Rust.
