### PR TITLE
Update for latest Rust nightly and updated dependencies

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(core, custom_derive, plugin, step_by, test)]
+#![feature(custom_derive, iter_arith, plugin, step_by, test)]
 #![cfg_attr(test, deny(missing_docs, warnings))]
 #![plugin(json_macros, num_macros, regex_macros)]
 

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -57,15 +57,17 @@ pub enum NextState {
 }
 
 mod prelude {
-    pub use packet::{BlockChangeRecord, ChunkMeta, Protocol, PacketRead, PacketWrite, Stat, NextState};
-    pub use proto::slp;
-    pub use types::consts::*;
-    pub use types::{Arr, BlockPos, ChunkColumn, NbtBlob, Slot, UuidString, Var};
-
     pub use std::io;
     pub use std::io::prelude::*;
 
+    pub use nbt;
+
     pub use uuid::Uuid;
+
+    pub use packet::{BlockChangeRecord, ChunkMeta, Protocol, PacketRead, PacketWrite, Stat, NextState};
+    pub use proto::slp;
+    pub use types::{Arr, BlockPos, ChunkColumn, Slot, UuidString, Var};
+    pub use types::consts::*;
 }
 
 macro_rules! packets {
@@ -455,7 +457,7 @@ pub mod play {
         0x46 => SetCompression { threshold: Var<i32> }
         // 0x47 => PlayerListHeaderFooter { header: Chat, footer: Chat }
         0x48 => ResourcePackSend { url: String, hash: String }
-        0x49 => UpdateEntityNbt { entity_id: Var<i32>, tag: NbtBlob }
+        0x49 => UpdateEntityNbt { entity_id: Var<i32>, tag: nbt::Blob }
     } }
     pub mod serverbound { packets! {
         0x00 => KeepAlive { keep_alive_id: i32 }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -15,7 +15,6 @@ pub use self::arr::Arr;
 pub use self::chat::ChatJson;
 pub use self::chunk::{Chunk, ChunkColumn};
 pub use self::entity_metadata::EntityMetadata;
-pub use nbt::{NbtBlob, NbtError, NbtValue};
 pub use self::pos::BlockPos;
 pub use self::selector::EntitySelector;
 pub use self::slot::Slot;

--- a/src/types/nbt.rs
+++ b/src/types/nbt.rs
@@ -1,21 +1,23 @@
-//! A protocol implementation for `NbtBlob`s.
+//! A protocol implementation for `nbt::Blob`s.
 
 use std::io;
-use nbt::NbtBlob;
+
+use nbt;
+
 use packet::Protocol;
 
-impl Protocol for NbtBlob {
-    type Clean = NbtBlob;
+impl Protocol for nbt::Blob {
+    type Clean = nbt::Blob;
 
-    fn proto_len(value: &NbtBlob) -> usize {
+    fn proto_len(value: &nbt::Blob) -> usize {
         value.len()
     }
 
-    fn proto_encode(value: &NbtBlob, mut dst: &mut io::Write) -> io::Result<()> {
+    fn proto_encode(value: &nbt::Blob, mut dst: &mut io::Write) -> io::Result<()> {
         Ok(try!(value.write(dst)))
     }
 
-    fn proto_decode(mut src: &mut io::Read) -> io::Result<NbtBlob> {
-        Ok(try!(NbtBlob::from_reader(src)))
+    fn proto_decode(mut src: &mut io::Read) -> io::Result<nbt::Blob> {
+        Ok(try!(nbt::Blob::from_reader(src)))
     }
 }

--- a/src/types/slot.rs
+++ b/src/types/slot.rs
@@ -3,15 +3,16 @@
 use std::io;
 use std::io::prelude::*;
 
+use nbt;
+
 use packet::Protocol;
-use types::NbtBlob;
 
 #[derive(Debug)]
 pub struct Slot {
     id: u16,
     count: u8,
     damage: i16,
-    tag: NbtBlob
+    tag: nbt::Blob
 }
 
 impl Protocol for Option<Slot> {
@@ -19,7 +20,7 @@ impl Protocol for Option<Slot> {
 
     fn proto_len(value: &Option<Slot>) -> usize {
         match *value {
-            Some(ref slot) => 2 + 1 + 2 + <NbtBlob as Protocol>::proto_len(&slot.tag), // id, count, damage, tag
+            Some(ref slot) => 2 + 1 + 2 + <nbt::Blob as Protocol>::proto_len(&slot.tag), // id, count, damage, tag
             None => 2
         }
     }
@@ -30,7 +31,7 @@ impl Protocol for Option<Slot> {
                 try!(<i16 as Protocol>::proto_encode(&(id as i16), dst));
                 try!(<u8 as Protocol>::proto_encode(&count, dst));
                 try!(<i16 as Protocol>::proto_encode(&damage, dst));
-                try!(<NbtBlob as Protocol>::proto_encode(tag, dst));
+                try!(<nbt::Blob as Protocol>::proto_encode(tag, dst));
             }
             None => { try!(<i16 as Protocol>::proto_encode(&-1, dst)) }
         }
@@ -46,7 +47,7 @@ impl Protocol for Option<Slot> {
                 id: id as u16,
                 count: try!(<u8 as Protocol>::proto_decode(src)),
                 damage: try!(<i16 as Protocol>::proto_decode(src)),
-                tag: try!(<NbtBlob as Protocol>::proto_decode(src))
+                tag: try!(<nbt::Blob as Protocol>::proto_decode(src))
             })
         })
     }


### PR DESCRIPTION
Some feature names have been changed, and [`nbt`](https://github.com/PistonDevelopers/hematite_nbt) changed `NbtBlob` to `nbt::Blob` etc.
