### PR TITLE
Move to Rust beta

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: rust
-rust: nightly
+rust: beta
 notifications:
   irc: "irc.mozilla.org#hematite"
 script:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-
 name = "hematite_server"
 version = "0.0.1"
 authors = [
@@ -21,17 +20,11 @@ path = "src/lib.rs"
 [dependencies]
 byteorder = "*"
 flate2 = "*"
-json_macros = "*"
 num = "*"
-#num-macros = "*"
 regex = "*"
-regex_macros = "*"
 rustc-serialize = "*"
 time = "*"
 uuid = "*"
 
 [dependencies.nbt]
 git = "https://github.com/PistonDevelopers/hematite_nbt.git"
-
-[dependencies.num-macros]
-git = "https://github.com/rust-lang/num.git" # crates.io version is outdated

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,5 @@
-#![feature(custom_derive, iter_arith, plugin, step_by, test)]
 #![cfg_attr(test, deny(missing_docs, warnings))]
 #![forbid(unused_variables)]
-#![plugin(json_macros, num_macros)]
 
 extern crate byteorder;
 extern crate flate2;
@@ -9,7 +7,6 @@ extern crate nbt;
 extern crate num;
 extern crate regex;
 extern crate rustc_serialize;
-extern crate test;
 extern crate time;
 extern crate uuid;
 

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -362,8 +362,8 @@ pub mod play {
                     let columns = this.chunk_meta.len() as i32;
                     1 // sky_light_sent(bool) len is constant
                     + <Var<i32> as Protocol>::proto_len(&columns)
-                    + this.chunk_meta.iter().map(<ChunkMeta as Protocol>::proto_len).sum::<usize>()
-                    + this.chunk_data.iter().map(|cd| cd.len()).sum::<usize>()
+                    + this.chunk_meta.iter().map(<ChunkMeta as Protocol>::proto_len).fold(0, |acc, item| acc + item)
+                    + this.chunk_data.iter().map(|cd| cd.len()).fold(0, |acc, item| acc + item)
                 }
                 fn proto_encode(this: &Self, mut dst: &mut Write) -> io::Result<()> {
                     try!(<bool as Protocol>::proto_encode(&this.sky_light_sent, dst));

--- a/src/types/arr.rs
+++ b/src/types/arr.rs
@@ -16,7 +16,7 @@ impl<L: Protocol, T: Protocol> Protocol for Arr<L, T> where L::Clean: NumCast {
 
     fn proto_len(value: &Vec<T::Clean>) -> usize {
         let len_len = <L as Protocol>::proto_len(&(<<L as Protocol>::Clean as NumCast>::from(value.len()).unwrap()));
-        let len_values = value.iter().map(<T as Protocol>::proto_len).sum::<usize>();
+        let len_values = value.iter().map(<T as Protocol>::proto_len).fold(0, |acc, item| acc + item);
         len_len + len_values
     }
 

--- a/src/types/chat.rs
+++ b/src/types/chat.rs
@@ -282,10 +282,10 @@ impl ToJson for ChatJson {
                 d.insert("text".to_string(), text.to_json());
             }
             Message::Score { ref name, ref objective } => {
-                d.insert("score".to_string(), json!({
-                    "name": (name),
-                    "objective": (objective)
-                }));
+                let mut score = json::Object::default();
+                score.insert("name".to_owned(), Json::String(name.clone()));
+                score.insert("objective".to_owned(), Json::String(objective.clone()));
+                d.insert("score".to_string(), Json::Object(score));
             }
             Message::Translatable(ref translate, ref with) => {
                 d.insert("translate".to_string(), translate.to_json());

--- a/src/types/chunk.rs
+++ b/src/types/chunk.rs
@@ -15,7 +15,7 @@ pub struct ChunkColumn {
 
 impl ChunkColumn {
     pub fn len(&self) -> usize {
-        let chunks = self.chunks.iter().map(|x| x.len()).sum::<usize>();
+        let chunks = self.chunks.iter().map(|x| x.len()).fold(0, |acc, item| acc + item);
         let biomes = match self.biomes {
             Some(_) => 256,
             None => 0

--- a/src/types/consts.rs
+++ b/src/types/consts.rs
@@ -37,11 +37,30 @@ macro_rules! enum_protocol_impl {
 enum_protocol_impl!(Dimension, i8, from_i8);
 
 #[repr(i8)]
-#[derive(Clone, Copy, Debug, NumFromPrimitive, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub enum Dimension {
     Nether = -1,
     Overworld = 0,
     End = 1
+}
+
+impl FromPrimitive for Dimension {
+    fn from_i64(n: i64) -> Option<Dimension> {
+        match n {
+            -1 => Some(Dimension::Nether),
+            0 => Some(Dimension::Overworld),
+            1 => Some(Dimension::End),
+            _ => None
+        }
+    }
+
+    fn from_u64(n: u64) -> Option<Dimension> {
+        match n {
+            0 => Some(Dimension::Overworld),
+            1 => Some(Dimension::End),
+            _ => None
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]

--- a/src/types/entity_metadata.rs
+++ b/src/types/entity_metadata.rs
@@ -55,7 +55,7 @@ impl Protocol for EntityMetadata {
                 | &Entry::Float3(_) => 12,
             }
         }
-        value.dict.values().map(entry_len).sum()
+        value.dict.values().map(entry_len).fold(0, |acc, item| acc + item)
     }
     fn proto_encode(value: &EntityMetadata, dst: &mut Write) -> io::Result<()> {
         fn key(k: u8, idx: u8) -> u8 {

--- a/src/types/pos.rs
+++ b/src/types/pos.rs
@@ -50,7 +50,7 @@ impl<T: Protocol> Protocol for [T; 3] {
     type Clean = [T::Clean; 3];
 
     fn proto_len(value: &[T::Clean; 3]) -> usize {
-        value.iter().map(|coord| <T as Protocol>::proto_len(coord)).sum()
+        value.iter().map(|coord| <T as Protocol>::proto_len(coord)).fold(0, |acc, item| acc + item)
     }
 
     fn proto_encode(value: &[T::Clean; 3], dst: &mut Write) -> io::Result<()> {

--- a/src/types/varnum.rs
+++ b/src/types/varnum.rs
@@ -43,7 +43,7 @@ impl Protocol for Var<i32> {
     fn proto_decode(mut src: &mut Read) -> io::Result<i32> {
         let mut x = 0i32;
 
-        for shift in (0..32).step_by(7) {
+        for shift in [0u32, 7, 14, 21, 28].into_iter() { // (0..32).step_by(7)
             let b = try!(src.read_u8()) as i32;
             x |= (b & 0x7F) << shift;
             if (b & 0x80) == 0 {
@@ -88,7 +88,7 @@ impl Protocol for Var<i64> {
     fn proto_decode(mut src: &mut Read) -> io::Result<i64> {
         let mut x = 0i64;
 
-        for shift in (0..64).step_by(7) {
+        for shift in [0u32, 7, 14, 21, 28, 35, 42, 49, 56, 63].into_iter() {
             let b = try!(src.read_u8()) as i64;
             x |= (b & 0x7F) << shift;
             if (b & 0x80) == 0 {


### PR DESCRIPTION
This removes the use of unstable features, allowing the crate to build on beta. In my opinion, master should run on stable Rust (which should be the case when this is merged and 1.2 is released), and the use of Rust beta/nightly should be restricted to snapshot and feature branches.

It also tells Travis CI to use the beta channel.

I'm not too sure about the [implementation of `<Dimension as FromPrimitive>::from_u64`](https://github.com/fenhl/hematite_server/blob/rust-beta/src/types/consts.rs#L57-L63).
