### PR TITLE
Move to stable Rust

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: rust
-rust: beta
 notifications:
   irc: "irc.mozilla.org#hematite"
 script:

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -9,7 +9,7 @@ use types::Var;
 
 /// A trait used for data which can be encoded/decoded as is.
 pub trait Protocol {
-    type Clean = Self;
+    type Clean;
 
     fn proto_len(value: &Self::Clean) -> usize;
     fn proto_encode(value: &Self::Clean, dst: &mut Write) -> io::Result<()>;


### PR DESCRIPTION
This fixes the build on stable Rust, and tells Travis CI to use the stable channel.
