### PR TITLE
Rename read_exact to read_exactly

### DIFF
--- a/src/types/chunk.rs
+++ b/src/types/chunk.rs
@@ -5,7 +5,7 @@ use std::io::prelude::*;
 use std::io::{self, Cursor};
 
 use packet::Protocol;
-use util::ReadExactExt;
+use util::ReadExactly;
 
 /// ChunkColumn is a set of 0-16 chunks, up to 16x256x16 blocks.
 pub struct ChunkColumn {
@@ -63,7 +63,7 @@ impl ChunkColumn {
             }
         }
         for chunk in &mut column.chunks {
-            // We use this instead of read_exact because it's an array, Vec is useless here.
+            // We use this instead of read_exactly because it's an array, Vec is useless here.
             for x in chunk.block_light.iter_mut() {
                 *x = try!(<u8 as Protocol>::proto_decode(src));
             }
@@ -73,7 +73,7 @@ impl ChunkColumn {
             // - 0x21 ChunkData uses `sky_light = dimension == Dimension::Overworld`
             // - 0x26 ChunkDataBulk uses `sky_light = true`
             if sky_light {
-                // We use this instead of read_exact because it's an array, Vec is useless here.
+                // We use this instead of read_exactly because it's an array, Vec is useless here.
                 let mut sl = [0u8; 2048];
                 for x in sl.iter_mut() {
                     *x = try!(<u8 as Protocol>::proto_decode(src));
@@ -82,7 +82,7 @@ impl ChunkColumn {
             }
         }
         if continuous {
-            let biomes = try!(src.read_exact(256));
+            let biomes = try!(src.read_exactly(256));
             // Vec<u8> -> [u8; 256]
             let mut bs = [0u8; 256];
             for (idx, elt) in biomes.into_iter().enumerate() {

--- a/src/types/string.rs
+++ b/src/types/string.rs
@@ -6,7 +6,7 @@ use std::io::prelude::*;
 
 use packet::Protocol;
 use types::Var;
-use util::ReadExactExt;
+use util::ReadExactly;
 
 /// UTF-8 string prefixed with its length as a VarInt.
 impl Protocol for String {
@@ -26,7 +26,7 @@ impl Protocol for String {
 
     fn proto_decode(mut src: &mut Read) -> io::Result<String> {
         let len: i32 = try!(<Var<i32> as Protocol>::proto_decode(src));
-        let s = try!(src.read_exact(len as usize));
+        let s = try!(src.read_exactly(len as usize));
         String::from_utf8(s).map_err(|utf8_err| io::Error::new(io::ErrorKind::InvalidInput, &format!("UTF-8 error: {}", utf8_err.utf8_error().description())[..]))
     }
 }

--- a/src/types/uuid.rs
+++ b/src/types/uuid.rs
@@ -6,7 +6,7 @@ use std::io;
 use std::str::FromStr;
 
 use packet::Protocol;
-use util::ReadExactExt;
+use util::ReadExactly;
 
 use uuid::{ParseError, Uuid};
 
@@ -20,7 +20,7 @@ impl Protocol for Uuid {
     }
     /// Reads 16 bytes from `src` and returns a `Uuid`
     fn proto_decode(mut src: &mut Read) -> io::Result<Uuid> {
-        let v = try!(src.read_exact(16));
+        let v = try!(src.read_exactly(16));
         Uuid::from_bytes(&v).ok_or(io::Error::new(io::ErrorKind::InvalidInput, &format!("Invalid UUID value: {:?} can't be used to create UUID", v)[..]))
     }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -3,11 +3,11 @@ use std::io::prelude::*;
 use std::iter::IntoIterator;
 use std::ops;
 
-pub trait ReadExactExt: Read {
+pub trait ReadExactly: Read {
     /// Returns a `Vec<u8>` containing the next `len` bytes in the reader.
     ///
     /// Adapted from `byteorder::read_full`.
-    fn read_exact(&mut self, len: usize) -> io::Result<Vec<u8>> {
+    fn read_exactly(&mut self, len: usize) -> io::Result<Vec<u8>> {
         let mut buf = vec![0; len];
         let mut n_read = 0usize;
         while n_read < buf.len() {
@@ -20,7 +20,7 @@ pub trait ReadExactExt: Read {
     }
 }
 
-impl<R: Read> ReadExactExt for R {}
+impl<R: Read> ReadExactly for R {}
 
 pub trait Join<T> {
     fn join(self, T) -> String;


### PR DESCRIPTION
Since std now has its own (unstable) `read_exact`, we need to rename our version to make it compile. The std `read_exact` can be used once it gets stabilized.
