### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,13 +18,11 @@ name = "hematite_server"
 path = "src/lib.rs"
 
 [dependencies]
-byteorder = "*"
-flate2 = "*"
-num = "*"
-regex = "*"
-rustc-serialize = "*"
-time = "*"
-uuid = "*"
-
-[dependencies.nbt]
-git = "https://github.com/PistonDevelopers/hematite_nbt.git"
+byteorder = "0.4"
+flate2 = "0.2"
+hematite-nbt = "0.1"
+num = "0.1"
+regex = "0.1"
+rustc-serialize = "0.3"
+time = "0.1"
+uuid = "0.1"


### PR DESCRIPTION
This replaces all the wildcards with standard semver compatibilities, and uses the crates.io version of hematite-nbt.
