### PR TITLE
First steps towards single player support

### DIFF
--- a/src/packet.rs
+++ b/src/packet.rs
@@ -66,7 +66,7 @@ mod prelude {
 
     pub use packet::{BlockChangeRecord, ChunkMeta, Protocol, PacketRead, PacketWrite, Stat, NextState};
     pub use proto::slp;
-    pub use types::{Arr, BlockPos, ChunkColumn, Slot, UuidString, Var};
+    pub use types::{Arr, BlockPos, ChatJson, ChunkColumn, Slot, UuidString, Var};
     pub use types::consts::*;
 }
 
@@ -319,7 +319,7 @@ pub mod play {
     pub mod clientbound { packets! {
         0x00 => KeepAlive { keep_alive_id: Var<i32> }
         0x01 => JoinGame { entity_id: i32, gamemode: u8, dimension: Dimension, difficulty: u8, max_players: u8, level_type: String, reduced_debug_info: bool }
-        // 0x02 => ChatMessage { data: Chat, position: i8 }
+        0x02 => ChatMessage { data: ChatJson, position: i8 }
         0x03 => TimeUpdate { world_age: i64, time_of_day: i64 }
         0x04 => EntityEquipment { entity_id: Var<i32>, slot: i16, item: Option<Slot> }
         0x05 => WorldSpawn { location: BlockPos }
@@ -445,7 +445,7 @@ pub mod play {
                 }
             }
         }
-        // 0x40 => Disconnect { reason: Chat }
+        0x40 => Disconnect { reason: ChatJson }
         0x41 => ServerDifficulty { difficulty: u8 }
         // 0x42 => PlayCombatEvent { event: CombatEvent }
         0x43 => Camera { camera_id: Var<i32> }
@@ -475,7 +475,7 @@ pub mod play {
         0x0f => ConfirmTransaction { window_id: u8, action_number: i16, accepted: bool }
         0x10 => CreativeInventoryAction { slot: i16, clicked_item: Option<Slot> }
         0x11 => EnchantItem { window_id: u8, enchantment: i8 }
-        // 0x12 => UpdateSign { location: BlockPos, line0: Chat, line1: Chat, line2: Chat, line3: Chat }
+        0x12 => UpdateSign { location: BlockPos, line0: ChatJson, line1: ChatJson, line2: ChatJson, line3: ChatJson }
         0x13 => PlayerAbilities { flags: i8, flying_speed: f32, walking_speed: f32 }
         0x14 => TabComplete { text: String, looking_at: Option<i64> }
         0x15 => ClientSettings { locale: String, view_distance: i8, chat_mode: i8, chat_colors: bool, displayed_skin_parts: u8 }
@@ -515,7 +515,7 @@ pub mod status {
 }
 pub mod login {
     pub mod clientbound { packets! {
-        // 0x00 => Disconnect { reason: Chat }
+        0x00 => Disconnect { reason: ChatJson }
         0x01 => EncryptionRequest { server_id: String, pubkey: Arr<Var<i32>, u8>, verify_token: Arr<Var<i32>, u8> }
         0x02 => LoginSuccess { uuid: UuidString, username: String }
         0x03 => SetCompression { threshold: Var<i32> }

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -419,7 +419,7 @@ pub mod play {
         // 0x35 => UpdateBlockEntity { location: [i32; 3], action: u8, nbt_data: Nbt; impl Protocol for UpdateBlockEntity { ... } } // PROBLEM: nbt_data is omitted entirely if it encodes an empty NBT tag
         0x36 => SignEditorOpen { location: BlockPos }
         0x37 => Statistics { stats: Arr<Var<i32>, Stat> }
-        // 0x38 => UpdatePlayerList { action: Var<i32>, players: Arr<Var<i32>, PlayerListItem>; impl Protocol for UpdatePlayerList { ... } } // PROBLEM: suructure of `players` elements depends on `action`
+        // 0x38 => UpdatePlayerList { action: Var<i32>, players: Arr<Var<i32>, PlayerListItem>; impl Protocol for UpdatePlayerList { ... } } // PROBLEM: structure of `players` elements depends on `action`
         0x39 => PlayerAbilities { flags: i8, flying_speed: f32, walking_speed: f32 }
         0x3a => TabComplete { matches: Arr<Var<i32>, String> }
         // 0x3b => ScoreboardObjective { objective_name: String, mode: ObjectiveAction }

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -457,7 +457,7 @@ pub mod play {
         0x49 => UpdateEntityNbt { entity_id: Var<i32>, tag: nbt::Blob }
     } }
     pub mod serverbound { packets! {
-        0x00 => KeepAlive { keep_alive_id: i32 }
+        0x00 => KeepAlive { keep_alive_id: Var<i32> }
         0x01 => ChatMessage { message: String }
         // 0x02 => UseEntity { target_eid: i32, use_type: EntityUseAction }
         0x03 => PlayerIdle { on_ground: bool }

--- a/src/types/chat.rs
+++ b/src/types/chat.rs
@@ -6,9 +6,30 @@ use std::str::FromStr;
 use rustc_serialize::{Encodable, Encoder};
 use rustc_serialize::json::{self, Json, ToJson};
 
+use packet::Protocol;
 use types::EntitySelector;
 use types::consts::Color;
 use types::selector;
+
+impl Protocol for ChatJson {
+    type Clean = ChatJson;
+
+    fn proto_len(value: &ChatJson) -> usize {
+        <String as Protocol>::proto_len(&(value.to_json().to_string()))
+    }
+
+    fn proto_encode(value: &ChatJson, mut dst: &mut io::Write) -> io::Result<()> {
+        let json_string = value.to_json().to_string();
+        Ok(try!(<String as Protocol>::proto_encode(&json_string, dst)))
+    }
+
+    fn proto_decode(mut src: &mut io::Read) -> io::Result<ChatJson> {
+        match ChatJson::from_reader(src) {
+            Ok(chat_json) => Ok(chat_json),
+            Err(err) => Err(io::Error::new(io::ErrorKind::Other, err))
+        }
+    }
+}
 
 #[derive(Debug)]
 pub enum JsonType {

--- a/src/vanilla/server.rs
+++ b/src/vanilla/server.rs
@@ -4,6 +4,7 @@ use std::fs;
 use std::io::{self, Write};
 use std::net::TcpStream;
 use std::path::Path;
+use std::sync::mpsc;
 
 use packet::{NextState, PacketRead, PacketWrite};
 use proto::properties::Properties;
@@ -12,20 +13,19 @@ use world::World;
 
 use uuid::Uuid;
 
-/// TODO(toqueteos): Move this to its own module. Proposal: src/vanilla/mod.rs
 pub struct Server {
     addr: String,
     props: Properties,
     // Dummy player storage, just their username.
     // players: Vec<String>,
-    worlds: Vec<World>
+    worlds: Vec<World>,
 }
 
 impl Server {
     pub fn new() -> io::Result<Server> {
         let properties_path = &Path::new("server.properties");
         let props = match fs::metadata(properties_path) {
-        // let props = match properties_path.metadata() {
+            // let props = match properties_path.metadata() {
             Ok(_) => try!(Properties::load(properties_path)),
             Err(_) => Properties::default(),
         };
@@ -42,20 +42,86 @@ impl Server {
             addr: addr,
             props: props,
             // players: vec![],
-            worlds: vec![World::new()]
+            worlds: vec![World::new()],
         })
     }
 
-    pub fn addr(&self) -> &str { return &self.addr }
-    pub fn port(&self) -> u16 { self.props.server_port }
+    pub fn addr(&self) -> &str {
+        return &self.addr;
+    }
+    pub fn port(&self) -> u16 {
+        self.props.server_port
+    }
+
+    pub fn keep_alive_loop(rx: mpsc::Receiver<TcpStream>) {
+        use std::ops::Add;
+        use std::thread;
+        use std::time::Duration;
+
+        use rand;
+
+        use packet::play::clientbound::KeepAlive;
+
+        let mut connections: Vec<TcpStream> = Vec::new();
+        loop {
+            // Try recv from channel for 5 seconds adding `TcpStream`s to connections
+            let mut timeout = Duration::new(0, 0);
+            loop {
+                match rx.try_recv() {
+                    Ok(stream) => {
+                        connections.push(stream);
+                    }
+                    Err(_) => {
+                        let delta = Duration::from_millis(30);
+                        thread::sleep(delta);
+                        timeout = timeout.add(delta);
+                    }
+                }
+                if timeout.as_secs() > 5 {
+                    break;
+                }
+            }
+
+            // Send KeepAlive packet "request"s
+            let mut length = connections.len();
+            let mut i: usize = 0;
+            while i < length {
+                let pkt = KeepAlive { keep_alive_id: rand::random() };
+                let peer_addr = connections[i].peer_addr().expect("<unknown peer addr>");
+                match pkt.write(&mut connections[i]) {
+                    Ok(_) => {
+                        info!("{} KeepAlive - keep_alive_id={}",
+                              peer_addr,
+                              pkt.keep_alive_id)
+                    }
+                    Err(_) => {
+                        connections.swap_remove(i);
+                        length -= 1;
+                        info!("Disconnected {}", peer_addr);
+                        continue;
+                    }
+                }
+                i += 1;
+            }
+
+            thread::sleep(Duration::from_secs(5));
+        }
+    }
 
     #[allow(unreachable_code)]
-    pub fn handle(&self, mut stream: TcpStream) -> io::Result<()> {
+    pub fn handle(&self,
+                  mut stream: TcpStream,
+                  keep_alive_tx: mpsc::Sender<TcpStream>)
+                  -> io::Result<()> {
         use packet::handshake::Packet::{self, Handshake};
         let state = match try!(Packet::read(&mut stream)) {
             Handshake(hs) => {
-                debug!("Handshake proto_version={} server_address={} server_port={} next_state={:?}",
-                         hs.proto_version, hs.server_address, hs.server_port, hs.next_state);
+                debug!("Handshake proto_version={} server_address={} server_port={} \
+                        next_state={:?}",
+                       hs.proto_version,
+                       hs.server_address,
+                       hs.server_port,
+                       hs.next_state);
                 hs.next_state
             }
         };
@@ -73,10 +139,16 @@ impl Server {
                     LoginStart(login) => login.name,
                     EncryptionResponse(_) => {
                         return Err(io::Error::new(io::ErrorKind::InvalidInput,
-                                   "Expecting login::serverbound::LoginStart packet, got EncryptionResponse"));
+                                                  "Expecting login::serverbound::LoginStart \
+                                                   packet, got EncryptionResponse"));
                     }
                 };
                 debug!(">> LoginStart name={}", name);
+
+                // {
+                //     use types::ChatJson;
+                //     try!(Disconnect { reason: ChatJson::from("Succesful login but still kicking you from Rust!") }.write(&mut stream));
+                // }
 
                 // NOTE: threshold of `-1` disables compression
                 let threshold = -1;
@@ -85,7 +157,11 @@ impl Server {
                 // try!(stream.flush());
 
                 // NOTE: UUID *MUST* be sent with hyphens
-                try!(LoginSuccess { uuid: Uuid::new_v4(), username: name }.write(&mut stream));
+                try!(LoginSuccess {
+                         uuid: Uuid::new_v4(),
+                         username: name,
+                     }
+                     .write(&mut stream));
                 debug!("<< LoginSuccess");
                 // try!(stream.flush());
 
@@ -98,7 +174,7 @@ impl Server {
                 try!(stream.flush());
 
                 // TODO(toqueteos): Determine player world and send `stream` to it.
-                try!(self.worlds[0].handle_player(stream));
+                try!(self.worlds[0].handle_player(stream, keep_alive_tx));
             }
         }
         Ok(())

--- a/src/world.rs
+++ b/src/world.rs
@@ -4,46 +4,13 @@
 
 use std::io::{self, Write};
 use std::net::TcpStream;
-use std::thread::sleep;
-use std::time::Duration;
 
-use packet::{ChunkMeta, PacketRead, PacketWrite, Protocol};
+use packet::{ChunkMeta, PacketRead, PacketWrite};
 use types::consts::*;
-use types::{Chunk, ChunkColumn, Var};
-use util::ReadExactly;
+use types::{Chunk, ChunkColumn};
 
 use rand;
 use time;
-
-// Temporal, only used within the BLOCK OF SHAME
-const PACKET_NAMES: [&'static str; 26] = [
-    "(c2s) KeepAlive",
-    "(c2s) ChatMessage",
-    "(c2s) UseEntity",
-    "(c2s) Player",
-    "(c2s) PlayerPosition",
-    "(c2s) PlayerLook",
-    "(c2s) PlayerPositionAndLook",
-    "(c2s) PlayerDigging",
-    "(c2s) PlayerBlockPlacement",
-    "(c2s) HeldItemChange",
-    "(c2s) Animation",
-    "(c2s) EntityAction",
-    "(c2s) SteerVehicle",
-    "(c2s) CloseWindow",
-    "(c2s) ClickWindow",
-    "(c2s) ConfirmTransaction",
-    "(c2s) CreativeInventoryAction",
-    "(c2s) EnchantItem",
-    "(c2s) UpdateSign",
-    "(c2s) PlayerAbilities",
-    "(c2s) TabComplete",
-    "(c2s) ClientSettings",
-    "(c2s) ClientStatus",
-    "(c2s) PluginMessage",
-    "(c2s) Spectate",
-    "(c2s) ResourcePackStatus"
-];
 
 /// World is a set of dimensions which tick in sync.
 pub struct World {
@@ -215,32 +182,298 @@ impl World {
         debug!("<< KeepAlive");
         try!(stream.flush());
 
-        // BLOCK OF SHAME
-        let mut t1 = time::get_time();
         loop {
-            let t2 = time::get_time();
-            let t = (t2 - t1).num_seconds();
+            match try!(Packet::read(&mut stream)) {
+                // 0x00 => KeepAlive { keep_alive_id: i32 }
+                Packet::KeepAlive(pkt) => {
+                    info!("0x00 KeepAlive - keep_alive_id={}", pkt.keep_alive_id);
+                }
+                // 0x01 => ChatMessage { message: String }
+                Packet::ChatMessage(pkt) => {
+                    use packet::play::clientbound::{ChatMessage, PlayerAbilities};
+                    use types::ChatJson;
 
-            // Manually skip over incoming packets
-            let len = try!(<Var<i32> as Protocol>::proto_decode(&mut stream));
-            let id = try!(<Var<i32> as Protocol>::proto_decode(&mut stream));
-            let n_read = len - 1;
-            let buf = try!(stream.read_exactly(n_read as usize));
-            // We could add a filter here, chat messages might be info!, position packets are debug!, etc...
-            debug!("id={} length={} buf={:?} t2-t={}", PACKET_NAMES[id as usize], len, buf, t);
+                    info!("0x01 ChatMessage - message={}", pkt.message);
 
-            // Send KeepAlive every 20 seconds, otherwise client times out
-            if t > 20 {
-                try!(KeepAlive { keep_alive_id: rand::random() }.write(&mut stream));
-                debug!("<< KeepAlive");
-                try!(stream.flush());
+                    match pkt.message.trim() {
+                        "/gamemode s" => {
+                            try!(PlayerAbilities {
+                                     flags: 0b0000, // god | can fly | flying | creative
+                                     flying_speed: 0.05,
+                                     walking_speed: 0.1,
+                                 }
+                                 .write(&mut stream));
+                        }
+                        "/gamemode c" => {
+                            try!(PlayerAbilities {
+                                     flags: 0b1101, // god | can fly | flying | creative
+                                     flying_speed: 0.05,
+                                     walking_speed: 0.1,
+                                 }
+                                 .write(&mut stream));
+                        }
+                        _ => {}
+                    }
 
-                t1 = time::get_time();
+                    let response = ChatMessage {
+                        data: ChatJson::from(pkt.message),
+                        position: 0,
+                    };
+                    try!(response.write(&mut stream));
+                }
+                // 0x02 => UseEntity { target_eid: i32, use_type: EntityUseAction }
+                // Packet::UseEntity(pkt) => {
+                //     info!("0x02 UseEntity");
+                // }
+                // 0x03 => PlayerIdle { on_ground: bool }
+                Packet::PlayerIdle(pkt) => {
+                    info!("0x03 PlayerIdle - on_ground={}", pkt.on_ground);
+                }
+                // 0x04 => PlayerPosition { position: [f64; 3], on_ground: bool }
+                Packet::PlayerPosition(pkt) => {
+                    info!("0x04 PlayerPosition - position={:?} on_ground={}",
+                          pkt.position,
+                          pkt.on_ground);
+                }
+                // 0x05 => PlayerLook { yaw: f32, pitch: f32, on_ground: bool }
+                Packet::PlayerLook(pkt) => {
+                    info!("0x05 PlayerLook - yaw={} pitch={} on_ground={}",
+                          pkt.yaw,
+                          pkt.pitch,
+                          pkt.on_ground);
+                }
+                // 0x06 => PlayerPositionAndLook { position: [f64; 3], yaw: f32, pitch: f32, on_ground: bool }
+                Packet::PlayerPositionAndLook(pkt) => {
+                    info!("0x06 PlayerPositionAndLook - position={:?} yaw={} pitch={} \
+                           on_ground={}",
+                          pkt.position,
+                          pkt.yaw,
+                          pkt.pitch,
+                          pkt.on_ground);
+                }
+                // 0x07 => PlayerDigging { status: i8, location: BlockPos, face: i8 }
+                Packet::PlayerDigging(pkt) => {
+                    info!("0x07 PlayerDigging - status={} location={:?} face={}",
+                          pkt.status,
+                          pkt.location,
+                          pkt.face);
+                }
+                // 0x08 => PlayerBlockPlacement { location: BlockPos, direction: i8, held_item: Option<Slot>, cursor: [i8; 3] }
+                Packet::PlayerBlockPlacement(pkt) => {
+                    info!("0x08 PlayerBlockPlacement - location={:?} direction={} held_item={:?} \
+                           cursor={:?}",
+                          pkt.location,
+                          pkt.direction,
+                          pkt.held_item,
+                          pkt.cursor);
+                }
+                // 0x09 => HeldItemChange { slot: i16 }
+                Packet::HeldItemChange(pkt) => {
+                    info!("0x09 HeldItemChange - slot={}", pkt.slot);
+                }
+                // 0x0a => Animation {}
+                Packet::Animation(_) => {
+                    info!("0x0a Animation");
+                }
+                // 0x0b => EntityAction { entity_id: Var<i32>, action_id: Var<i32>, jump_boost: Var<i32> }
+                Packet::EntityAction(pkt) => {
+                    info!("0x0b EntityAction - entity_id={} action_id={} jump_boost={}",
+                          pkt.entity_id,
+                          pkt.action_id,
+                          pkt.jump_boost);
+                }
+                // 0x0c => SteerVehicle { sideways: f32, forward: f32, flags: u8 }
+                Packet::SteerVehicle(pkt) => {
+                    info!("0x0c SteerVehicle - sideways={} forward={} flags={}",
+                          pkt.sideways,
+                          pkt.forward,
+                          pkt.flags);
+                }
+                // 0x0d => CloseWindow { window_id: u8 }
+                Packet::CloseWindow(pkt) => {
+                    info!("0x0d CloseWindow - window_id={}", pkt.window_id);
+                }
+                // 0x0e => ClickWindow { window_id: u8, slot: i16, button: i8, action_number: i16, mode: i8, clicked_item: Option<Slot> }
+                Packet::ClickWindow(pkt) => {
+                    info!("0x0e ClickWindow - window_id={} button={} action_number={} mode={} \
+                           clicked_item={:?}",
+                          pkt.window_id,
+                          pkt.button,
+                          pkt.action_number,
+                          pkt.mode,
+                          pkt.clicked_item);
+                }
+                // 0x0f => ConfirmTransaction { window_id: u8, action_number: i16, accepted: bool }
+                Packet::ConfirmTransaction(pkt) => {
+                    info!("0x0f ConfirmTransaction - window_id={} action_number={} accepted={}",
+                          pkt.window_id,
+                          pkt.action_number,
+                          pkt.accepted);
+                }
+                // 0x10 => CreativeInventoryAction { slot: i16, clicked_item: Option<Slot> }
+                Packet::CreativeInventoryAction(pkt) => {
+                    info!("0x10 CreativeInventoryAction - slot={} clicked_item={:?}",
+                          pkt.slot,
+                          pkt.clicked_item);
+                }
+                // 0x11 => EnchantItem { window_id: u8, enchantment: i8 }
+                Packet::EnchantItem(pkt) => {
+                    info!("0x11 EnchantItem - window_id={} enchantment={}",
+                          pkt.window_id,
+                          pkt.enchantment);
+                }
+                // 0x12 => UpdateSign { location: BlockPos, line0: ChatJson, line1: ChatJson, line2: ChatJson, line3: ChatJson }
+                Packet::UpdateSign(pkt) => {
+                    info!("0x12 UpdateSign - location={:?} line0={:?} line1={:?} line2={:?} \
+                           line3={:?}",
+                          pkt.location,
+                          pkt.line0,
+                          pkt.line1,
+                          pkt.line2,
+                          pkt.line3);
+                }
+                // 0x13 => PlayerAbilities { flags: i8, flying_speed: f32, walking_speed: f32 }
+                Packet::PlayerAbilities(pkt) => {
+                    info!("0x13 PlayerAbilities - flags={} flying_speed={} walking_speed={}",
+                          pkt.flags,
+                          pkt.flying_speed,
+                          pkt.walking_speed);
+                }
+                // 0x14 => TabComplete { text: String, looking_at: Option<i64> }
+                Packet::TabComplete(pkt) => {
+                    info!("0x14 TabComplete - text={} looking_at={:?}",
+                          pkt.text,
+                          pkt.looking_at);
+                }
+                // 0x15 => ClientSettings { locale: String, view_distance: i8, chat_mode: i8, chat_colors: bool, displayed_skin_parts: u8 }
+                Packet::ClientSettings(pkt) => {
+                    info!("0x15 ClientSettings - locale={} view_distance={} chat_mode={} \
+                           chat_colors={} displayed_skin_parts={}",
+                          pkt.locale,
+                          pkt.view_distance,
+                          pkt.chat_mode,
+                          pkt.chat_colors,
+                          pkt.displayed_skin_parts);
+                }
+                // 0x16 => ClientStatus { action_id: Var<i32> }
+                Packet::ClientStatus(pkt) => {
+                    info!("0x16 ClientStatus - action_id={}", pkt.action_id);
+
+                    match pkt.action_id {
+                        1 | 2 => {
+                            use packet::Stat;
+                            use packet::play::clientbound::Statistics;
+
+                            let stats = vec![
+                            Stat { name: "achievement.openInventory".to_string(), value: 1 },
+                            Stat { name: "achievement.mineWood".to_string(), value: 0 },
+                            Stat { name: "achievement.buildWorkBench".to_string(), value: 0 },
+                            Stat { name: "achievement.buildPickaxe".to_string(), value: 0 },
+                            Stat { name: "achievement.buildFurnace".to_string(), value: 0 },
+                            Stat { name: "achievement.acquireIron".to_string(), value: 0 },
+                            Stat { name: "achievement.buildHoe".to_string(), value: 0 },
+                            Stat { name: "achievement.makeBread".to_string(), value: 0 },
+                            Stat { name: "achievement.bakeCake".to_string(), value: 0 },
+                            Stat { name: "achievement.buildBetterPickaxe".to_string(), value: 0 },
+                            Stat { name: "achievement.cookFish".to_string(), value: 0 },
+                            Stat { name: "achievement.onARail".to_string(), value: 0 },
+                            Stat { name: "achievement.buildSword".to_string(), value: 0 },
+                            Stat { name: "achievement.killEnemy".to_string(), value: 0 },
+                            Stat { name: "achievement.killCow".to_string(), value: 0 },
+                            Stat { name: "achievement.flyPig".to_string(), value: 0 },
+                            Stat { name: "achievement.snipeSkeleton".to_string(), value: 0 },
+                            Stat { name: "achievement.diamonds".to_string(), value: 0 },
+                            Stat { name: "achievement.diamondsToYou".to_string(), value: 0 },
+                            Stat { name: "achievement.portal".to_string(), value: 0 },
+                            Stat { name: "achievement.ghast".to_string(), value: 0 },
+                            Stat { name: "achievement.blazeRod".to_string(), value: 0 },
+                            Stat { name: "achievement.potion".to_string(), value: 0 },
+                            Stat { name: "achievement.theEnd".to_string(), value: 0 },
+                            Stat { name: "achievement.theEnd2".to_string(), value: 0 },
+                            Stat { name: "achievement.enchantments".to_string(), value: 0 },
+                            Stat { name: "achievement.overkill".to_string(), value: 0 },
+                            Stat { name: "achievement.bookcase".to_string(), value: 0 },
+                            Stat { name: "achievement.breedCow".to_string(), value: 0 },
+                            Stat { name: "achievement.spawnWither".to_string(), value: 0 },
+                            Stat { name: "achievement.killWither".to_string(), value: 0 },
+                            Stat { name: "achievement.fullBeacon".to_string(), value: 0 },
+                            Stat { name: "achievement.exploreAllBiomes".to_string(), value: 0 },
+                            Stat { name: "stat.leaveGame".to_string(), value: 0 },
+                            Stat { name: "stat.playOneMinute".to_string(), value: 0 },
+                            Stat { name: "stat.timeSinceDeath".to_string(), value: 0 },
+                            Stat { name: "stat.sneakTime".to_string(), value: 0 },
+                            Stat { name: "stat.walkOneCm".to_string(), value: 0 },
+                            Stat { name: "stat.crouchOneCm".to_string(), value: 0 },
+                            Stat { name: "stat.sprintOneCm".to_string(), value: 0 },
+                            Stat { name: "stat.swimOneCm".to_string(), value: 0 },
+                            Stat { name: "stat.fallOneCm".to_string(), value: 0 },
+                            Stat { name: "stat.climbOneCm".to_string(), value: 0 },
+                            Stat { name: "stat.flyOneCm".to_string(), value: 0 },
+                            Stat { name: "stat.diveOneCm".to_string(), value: 0 },
+                            Stat { name: "stat.minecartOneCm".to_string(), value: 0 },
+                            Stat { name: "stat.boatOneCm".to_string(), value: 0 },
+                            Stat { name: "stat.pigOneCm".to_string(), value: 0 },
+                            Stat { name: "stat.horseOneCm".to_string(), value: 0 },
+                            Stat { name: "stat.aviateOneCm".to_string(), value: 0 },
+                            Stat { name: "stat.jump".to_string(), value: 0 },
+                            Stat { name: "stat.damageDealt".to_string(), value: 0 },
+                            Stat { name: "stat.damageTaken".to_string(), value: 0 },
+                            Stat { name: "stat.deaths".to_string(), value: 0 },
+                            Stat { name: "stat.mobKills".to_string(), value: 0 },
+                            Stat { name: "stat.playerKills".to_string(), value: 0 },
+                            Stat { name: "stat.drop".to_string(), value: 0 },
+                            Stat { name: "stat.itemEnchanted".to_string(), value: 0 },
+                            Stat { name: "stat.animalsBred".to_string(), value: 0 },
+                            Stat { name: "stat.fishCaught".to_string(), value: 0 },
+                            Stat { name: "stat.junkFished".to_string(), value: 0 },
+                            Stat { name: "stat.treasureFished".to_string(), value: 0 },
+                            Stat { name: "stat.talkedToVillager".to_string(), value: 0 },
+                            Stat { name: "stat.tradedWithVillager".to_string(), value: 0 },
+                            Stat { name: "stat.cakeSlicesEaten".to_string(), value: 0 },
+                            Stat { name: "stat.cauldronFilled".to_string(), value: 0 },
+                            Stat { name: "stat.cauldronUsed".to_string(), value: 0 },
+                            Stat { name: "stat.armorCleaned".to_string(), value: 0 },
+                            Stat { name: "stat.bannerCleaned".to_string(), value: 0 },
+                            Stat { name: "stat.brewingstandInteraction".to_string(), value: 0 },
+                            Stat { name: "stat.beaconInteraction".to_string(), value: 0 },
+                            Stat { name: "stat.craftingTableInteraction".to_string(), value: 0 },
+                            Stat { name: "stat.furnaceInteraction".to_string(), value: 0 },
+                            Stat { name: "stat.dispenserInspected".to_string(), value: 0 },
+                            Stat { name: "stat.dropperInspected".to_string(), value: 0 },
+                            Stat { name: "stat.hopperInspected".to_string(), value: 0 },
+                            Stat { name: "stat.chestOpened".to_string(), value: 0 },
+                            Stat { name: "stat.trappedChestTriggered".to_string(), value: 0 },
+                            Stat { name: "stat.enderchestOpened".to_string(), value: 0 },
+                            Stat { name: "stat.noteblockPlayed".to_string(), value: 0 },
+                            Stat { name: "stat.noteblockTuned".to_string(), value: 0 },
+                            Stat { name: "stat.flowerPotted".to_string(), value: 0 },
+                            Stat { name: "stat.recordPlayed".to_string(), value: 0 },
+                            Stat { name: "stat.sleepInBed".to_string(), value: 0 },
+                        ];
+                            let response = Statistics { stats: stats };
+                            try!(response.write(&mut stream));
+                        }
+                        _ => {}
+                    }
+                }
+                // 0x17 => PluginMessage { channel: String, data: Vec<u8> }
+                Packet::PluginMessage(pkt) => {
+                    info!("0x17 PluginMessage - channel={} data={:?}",
+                          pkt.channel,
+                          pkt.data);
+                }
+                // 0x18 => Spectate { target_player: Uuid }
+                Packet::Spectate(pkt) => {
+                    info!("0x18 Spectate - target_player={}", pkt.target_player);
+                }
+                // 0x19 => ResourcePackStatus { hash: String, result: Var<i32> }
+                Packet::ResourcePackStatus(pkt) => {
+                    info!("0x19 ResourcePackStatus - hash={} result={}",
+                          pkt.hash,
+                          pkt.result);
+                }
             }
-
-            sleep(Duration::from_millis(15));
         }
-        // /BLOCK OF SHAME
 
         Ok(())
     }

--- a/src/world.rs
+++ b/src/world.rs
@@ -47,14 +47,15 @@ impl World {
         // - Read world info from disk
         // - Read some keypairs from server.properties
         try!(JoinGame {
-            entity_id: 0,
-            gamemode: 0b0010,
-            dimension: Dimension::Overworld,
-            difficulty: 2,
-            max_players: 20,
-            level_type: "default".to_string(),
-            reduced_debug_info: false
-        }.write(&mut stream));
+                 entity_id: 0,
+                 gamemode: 0b0000, // 0: Survival, 1: Creative, 2: Adventure, 3: Spectator
+                 dimension: Dimension::Overworld,
+                 difficulty: 2,
+                 max_players: 20,
+                 level_type: "default".to_string(),
+                 reduced_debug_info: false,
+             }
+             .write(&mut stream));
         debug!("<< JoinGame");
         // try!(stream.flush());
 
@@ -62,10 +63,11 @@ impl World {
         // are good, now they are just taken from Glowstone impl.
         // `flags` value is read from server's player list.
         try!(PlayerAbilities {
-            flags: 0b1101, // flying and creative
-            flying_speed: 0.05,
-            walking_speed: 0.1
-        }.write(&mut stream));
+                 flags: 0b0000, // god | can fly | flying | creative
+                 flying_speed: 0.05,
+                 walking_speed: 0.1,
+             }
+             .write(&mut stream));
         debug!("<< PlayerAbilities");
         // try!(stream.flush());
 
@@ -138,15 +140,6 @@ impl World {
         try!(ChangeGameState { reason: 9, value: 0.0 }.write(&mut stream));
         debug!("<< ChangeGameState SkyDarkness");
         // try!(stream.flush());
-
-        // Send Abilities
-        try!(PlayerAbilities {
-            flags: 0b1101, // flying and creative
-            flying_speed: 0.05,
-            walking_speed: 0.1
-        }.write(&mut stream));
-        debug!("<< PlayerAbilities");
-        try!(stream.flush());
 
         // // Send Inventory items
         // let wi = ClientWindowItems {

--- a/src/world.rs
+++ b/src/world.rs
@@ -57,7 +57,6 @@ impl World {
              }
              .write(&mut stream));
         debug!("<< JoinGame");
-        // try!(stream.flush());
 
         // FIXME(toqueteos): Verify `flying_speed` and `walking_speed` values
         // are good, now they are just taken from Glowstone impl.
@@ -69,7 +68,6 @@ impl World {
              }
              .write(&mut stream));
         debug!("<< PlayerAbilities");
-        // try!(stream.flush());
 
         // WRITE `MC|Brand` plugin
         try!(PluginMessage {
@@ -77,7 +75,6 @@ impl World {
             data: b"hematite".to_vec()
         }.write(&mut stream));
         debug!("<< PluginMessage");
-        // try!(stream.flush());
 
         // WRITE supported channels
         try!(PluginMessage {
@@ -85,7 +82,6 @@ impl World {
             data: b"MC|Brand\0".to_vec()
         }.write(&mut stream));
         debug!("<< PluginMessage");
-        // try!(stream.flush());
 
         // FIXME(toqueteos): We need a chunk loader handling disk reads and
         // using real chunks not made up ones.
@@ -111,12 +107,10 @@ impl World {
             chunk_data: data,
         }.write(&mut stream));
         debug!("<< ChunkDataBulk");
-        // try!(stream.flush());
 
         // Send Compass
         try!(WorldSpawn { location: [10, 65, 10] }.write(&mut stream));
         debug!("<< WorldSpawn");
-        // try!(stream.flush());
 
         // Send Time
         try!(TimeUpdate {
@@ -124,22 +118,18 @@ impl World {
             time_of_day: self.time_of_day()
         }.write(&mut stream));
         debug!("<< TimeUpdate");
-        // try!(stream.flush());
 
         // Send Weather
         try!(ChangeGameState { reason: 1, value: 0.0 }.write(&mut stream));
         debug!("<< ChangeGameState Weather");
-        // try!(stream.flush());
 
         // Send RainDensity
         try!(ChangeGameState { reason: 8, value: 0.0 }.write(&mut stream));
         debug!("<< ChangeGameState RainDensity");
-        // try!(stream.flush());
 
         // Send SkyDarkness
         try!(ChangeGameState { reason: 9, value: 0.0 }.write(&mut stream));
         debug!("<< ChangeGameState SkyDarkness");
-        // try!(stream.flush());
 
         // // Send Inventory items
         // let wi = ClientWindowItems {
@@ -148,7 +138,6 @@ impl World {
         // };
         // try!(wi.write(&mut stream));
         debug!("<< WindowItems (not sent)");
-        // try!(stream.flush());
 
         try!(PlayerPositionAndLook {
             position: [0.0, 64.0, 0.0],
@@ -157,7 +146,6 @@ impl World {
             flags: 0x1f
         }.write(&mut stream));
         debug!("<< PlayerPositionAndLook");
-        // try!(stream.flush());
 
         // Read Client Settings
         match try!(Packet::read(&mut stream)) {
@@ -168,7 +156,6 @@ impl World {
         // let cm = ChatMessage { data: Chat::new("Server: Welcome to hematite server!"), position: 1 };
         // try!(cm.write(&mut stream));
         // debug!("<< ChatMessage data={:?} position={}", cm.data, cm.position);
-        // try!(stream.flush());
 
         // Send first Keep Alive
         try!(KeepAlive { keep_alive_id: rand::random() }.write(&mut stream));


### PR DESCRIPTION
I've been working on the single player support for hematite_server. I created the PR so we can comment on lines, there's stuff happening just not that visible.
- [x] Rust v1.5
- [ ] `rustfmt`
  - Unfortunately it causes a bit of a mess, we won't use it for now
- [x] Documentation:
  - [ ] Whatever gets added has docs
  - [ ] NON-Goal. Docs for everything I can catch
- [x] List of changes:
  - [x] Got rid of the BLOCK OF SHAME! :tada:
  - [x] Keep Alive based on channels as https://github.com/RichardlL/Tunnul does!
  - [x] First steps towards supporting single player #97
  - [x] `serverbound::KeepAlive` was `i32` instead of `Var<i32>`.
  - [x] `clientbound::PlayerAbilities` being sent twice, with bad params
  - [x] Gamemode set to survival by default, instead of adventure.

/cc @fenhl @RichardlL 
