### PR TITLE
Add a consts module containing version number and protocol version

### DIFF
--- a/src/consts.rs
+++ b/src/consts.rs
@@ -1,0 +1,2 @@
+pub const PROTO_VERSION: i32 = 47;
+pub const VERSION: &'static str = "1.8.9";

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@ extern crate rustc_serialize;
 extern crate time;
 extern crate uuid;
 
+pub mod consts;
 pub mod packet;
 pub mod proto;
 pub mod types;

--- a/src/proto/slp.rs
+++ b/src/proto/slp.rs
@@ -10,6 +10,7 @@ use std::net::TcpStream;
 use std::ops::Sub; // Sub for Timespec
 use std::path::Path;
 
+use consts;
 use packet::{PacketRead, PacketWrite, Protocol};
 
 use rustc_serialize::base64::{ToBase64, STANDARD};
@@ -88,8 +89,8 @@ pub fn response(mut stream: &mut TcpStream) -> io::Result<()> {
             // other values are static.
             let resp = Response{
                 version: Version{
-                    name: "1.8.3".to_string(),
-                    protocol: 47,
+                    name: consts::VERSION.to_string(),
+                    protocol: consts::PROTO_VERSION,
                 },
                 players: Players{
                     // FIXME(toqueteos): This is value should be a internal counter of server
@@ -181,7 +182,7 @@ mod tests {
     fn client_server_list_ping() {
         let mut stream = TcpStream::connect("127.0.0.1:25565").unwrap();
         Handshake {
-            proto_version: 47,
+            proto_version: consts::PROTO_VERSION,
             server_address: "127.0.0.1".to_string(),
             server_port: 25565,
             next_state: NextState::Status
@@ -200,7 +201,7 @@ mod tests {
         let elapsed = ping(&mut stream).unwrap();
         println!("ping {}", elapsed);
         Handshake {
-            proto_version: 47,
+            proto_version: consts::PROTO_VERSION,
             server_address: "127.0.0.1".to_string(),
             server_port: 25565,
             next_state: NextState::Status


### PR DESCRIPTION
This should make it easier to update them. Also bumped to 1.8.9 while I was at it.
