### PR TITLE
Impl symmetric AES encryption on top of TcpStream

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,12 +23,9 @@ flate2 = "0.2"
 hematite-nbt = "0.1"
 log = "0.3"
 num = "0.1"
+openssl = "0.7.5"
 rand = "0.3"
 regex = "0.1"
 rustc-serialize = "0.3"
 time = "0.1"
 uuid = "0.1"
-
-[dependencies.openssl]
-git = "https://github.com/sfackler/rust-openssl.git"
-rev = "83ef18922f2534c6c57e72a34233a3a3d4ae3aa3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,3 +28,7 @@ regex = "0.1"
 rustc-serialize = "0.3"
 time = "0.1"
 uuid = "0.1"
+
+[dependencies.openssl]
+git = "https://github.com/sfackler/rust-openssl.git"
+rev = "83ef18922f2534c6c57e72a34233a3a3d4ae3aa3"

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -1,0 +1,54 @@
+use std::io::{Read, Write, Result};
+use std::net::TcpStream;
+use openssl::crypto::symm::{Crypter, Mode, Type};
+
+pub struct SymmStream {
+    stream: TcpStream,
+    encrypter: Crypter,
+    decrypter: Crypter,
+}
+
+impl SymmStream {
+    pub fn new(stream: TcpStream, shared_secret: &[u8]) -> SymmStream {
+        let encrypter = Crypter::new(Type::AES_128_CFB8);
+        let decrypter = Crypter::new(Type::AES_128_CFB8);
+
+        encrypter.init(Mode::Encrypt, shared_secret, shared_secret);
+        decrypter.init(Mode::Decrypt, shared_secret, shared_secret);
+
+        SymmStream {
+            stream: stream,
+            encrypter: encrypter,
+            decrypter: decrypter,
+        }
+    }
+}
+
+impl Read for SymmStream {
+    fn read(&mut self, mut out: &mut [u8]) -> Result<usize> {
+        use std::io;
+
+        let stream = <TcpStream as Read>::by_ref(&mut self.stream);
+
+        let mut cipher = Vec::new();
+        try!(stream.take(out.len() as u64).read_to_end(&mut cipher));
+
+        let plain = self.decrypter.update(&cipher[..]);
+
+        io::copy(&mut &plain[..], &mut out).map(|r| r as usize)
+    }
+}
+
+impl Write for SymmStream {
+    fn write(&mut self, buf: &[u8]) -> Result<usize> {
+        try!(self.stream.write(&self.encrypter.update(buf)[..]));
+
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> Result<()> {
+        try!(self.stream.write(&self.encrypter.finalize()[..]));
+
+        self.stream.flush()
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ extern crate flate2;
 extern crate log;
 extern crate nbt;
 extern crate num;
+extern crate openssl;
 extern crate rand;
 extern crate regex;
 extern crate rustc_serialize;
@@ -16,6 +17,7 @@ extern crate time;
 extern crate uuid;
 
 pub mod consts;
+pub mod crypto;
 pub mod packet;
 pub mod proto;
 pub mod types;

--- a/src/world.rs
+++ b/src/world.rs
@@ -2,8 +2,7 @@
 //!
 //! This module is a WORK IN PROGRESS.
 
-use std::io::{self, Write};
-use std::net::TcpStream;
+use std::io::{self, Read, Write};
 use std::thread::sleep;
 use std::time::Duration;
 
@@ -68,7 +67,7 @@ impl World {
     }
 
     #[allow(unreachable_code)]
-    pub fn handle_player(&self, mut stream: TcpStream) -> io::Result<()> {
+    pub fn handle_player<S: Read + Write>(&self, mut stream: S) -> io::Result<()> {
         use packet::play::serverbound::Packet;
         use packet::play::serverbound::Packet::ClientSettings;
         use packet::play::clientbound::{ChangeGameState, ChunkDataBulk, JoinGame, KeepAlive};


### PR DESCRIPTION
- The server will now generate a 1024-bit certificate and corresponding private key at startup which is used during the encryption handshake (the certificates public key is sent to the client after which the private key is used to decrypt the shared secret).
- Upon success the `TcpStream` is wrapped in the `SymmStream` type, after which all subsequent reads and writes are passed through two separate 128-bit AES ciphers (`decrypter` and `encrypter` respectively.)

The clients response is not verified atm, since the `login::clientbound::Disconnect` packet isn't implemented (guessing it won't be long, since @toqueteos [has made efforts towards encoding ChatJson?](https://github.com/toqueteos/hematite_server/commit/b3ee689d55e1d68bdbc44d224eaa18bcb2a85fc0))

The nonce isn't randomly generated either, which I suppose isn't strictly necessary, but would be nice to have. [It's also how cuberite does it (kind of.)](https://github.com/cuberite/cuberite/blob/83418e1d7a31e247b0d7892e75e70abc14b9aad8/src/Protocol/Protocol18x.cpp#L2205-L2206)

I'm also not happy with overruling the compiler in terms of `Send` and `Sync` safety (see [src/vanilla/server.rs](https://github.com/bheart/hematite_server/blob/b47d99ed3f6f891c149d4fbd9468af5b2d8618be/src/vanilla/server.rs#L144-L145)), but I'm under the impression that the `openssl` crate is as thread safe as it can get, and that marking `PKey`s as such is a non-issue (I could totally be wrong, I'm not particularly well versed in Rust.)

Still to do:
- [ ] Verify `verify_token`
- [ ] Generate `verify_token` as opposed to hardcoding it
- [x] Resolve thread safety issues (if any?)
