### PR TITLE
Replace ReadExactly trait with read_exact from std

### DIFF
--- a/src/types/chunk.rs
+++ b/src/types/chunk.rs
@@ -5,7 +5,6 @@ use std::io::prelude::*;
 use std::io::{self, Cursor};
 
 use packet::Protocol;
-use util::ReadExactly;
 
 /// ChunkColumn is a set of 0-16 chunks, up to 16x256x16 blocks.
 pub struct ChunkColumn {
@@ -82,13 +81,9 @@ impl ChunkColumn {
             }
         }
         if continuous {
-            let biomes = try!(src.read_exactly(256));
-            // Vec<u8> -> [u8; 256]
-            let mut bs = [0u8; 256];
-            for (idx, elt) in biomes.into_iter().enumerate() {
-                bs[idx] = elt;
-            }
-            column.biomes = Some(bs)
+            let mut biomes = [0u8; 256];
+            try!(src.read_exact(&mut biomes));
+            column.biomes = Some(biomes)
         }
         Ok(column)
     }

--- a/src/types/string.rs
+++ b/src/types/string.rs
@@ -25,7 +25,7 @@ impl Protocol for String {
 
     fn proto_decode(mut src: &mut Read) -> io::Result<String> {
         let len: i32 = try!(<Var<i32> as Protocol>::proto_decode(src));
-        let mut s = vec![0; len as usize];
+        let mut s = vec![0u8; len as usize];
         try!(src.read_exact(&mut s));
         String::from_utf8(s).map_err(|utf8_err| io::Error::new(io::ErrorKind::InvalidInput, &format!("UTF-8 error: {}", utf8_err.utf8_error().description())[..]))
     }

--- a/src/types/string.rs
+++ b/src/types/string.rs
@@ -6,7 +6,6 @@ use std::io::prelude::*;
 
 use packet::Protocol;
 use types::Var;
-use util::ReadExactly;
 
 /// UTF-8 string prefixed with its length as a VarInt.
 impl Protocol for String {
@@ -26,7 +25,8 @@ impl Protocol for String {
 
     fn proto_decode(mut src: &mut Read) -> io::Result<String> {
         let len: i32 = try!(<Var<i32> as Protocol>::proto_decode(src));
-        let s = try!(src.read_exactly(len as usize));
+        let mut s = vec![0; len as usize];
+        try!(src.read_exact(&mut s));
         String::from_utf8(s).map_err(|utf8_err| io::Error::new(io::ErrorKind::InvalidInput, &format!("UTF-8 error: {}", utf8_err.utf8_error().description())[..]))
     }
 }

--- a/src/types/uuid.rs
+++ b/src/types/uuid.rs
@@ -6,7 +6,6 @@ use std::io;
 use std::str::FromStr;
 
 use packet::Protocol;
-use util::ReadExactly;
 
 use uuid::{ParseError, Uuid};
 
@@ -20,7 +19,8 @@ impl Protocol for Uuid {
     }
     /// Reads 16 bytes from `src` and returns a `Uuid`
     fn proto_decode(mut src: &mut Read) -> io::Result<Uuid> {
-        let v = try!(src.read_exactly(16));
+        let mut v = [0u8; 16];
+        try!(src.read_exact(&mut v));
         Uuid::from_bytes(&v).ok_or(io::Error::new(io::ErrorKind::InvalidInput, &format!("Invalid UUID value: {:?} can't be used to create UUID", v)[..]))
     }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,26 +1,5 @@
-use std::io;
-use std::io::prelude::*;
 use std::iter::IntoIterator;
 use std::ops;
-
-pub trait ReadExactly: Read {
-    /// Returns a `Vec<u8>` containing the next `len` bytes in the reader.
-    ///
-    /// Adapted from `byteorder::read_full`.
-    fn read_exactly(&mut self, len: usize) -> io::Result<Vec<u8>> {
-        let mut buf = vec![0; len];
-        let mut n_read = 0usize;
-        while n_read < buf.len() {
-            match try!(self.read(&mut buf[n_read..])) {
-                0 => { return Err(io::Error::new(io::ErrorKind::InvalidInput, "unexpected EOF")); }
-                n => n_read += n
-            }
-        }
-        Ok(buf)
-    }
-}
-
-impl<R: Read> ReadExactly for R {}
 
 pub trait Join<T> {
     fn join(self, T) -> String;

--- a/src/world.rs
+++ b/src/world.rs
@@ -2,7 +2,7 @@
 //!
 //! This module is a WORK IN PROGRESS.
 
-use std::io::{self, Write};
+use std::io::{self, Read, Write};
 use std::net::TcpStream;
 use std::thread::sleep;
 use std::time::Duration;
@@ -10,7 +10,6 @@ use std::time::Duration;
 use packet::{ChunkMeta, PacketRead, PacketWrite, Protocol};
 use types::consts::*;
 use types::{Chunk, ChunkColumn, Var};
-use util::ReadExactly;
 
 use rand;
 use time;
@@ -225,7 +224,8 @@ impl World {
             let len = try!(<Var<i32> as Protocol>::proto_decode(&mut stream));
             let id = try!(<Var<i32> as Protocol>::proto_decode(&mut stream));
             let n_read = len - 1;
-            let buf = try!(stream.read_exactly(n_read as usize));
+            let mut buf = vec![0; n_read as usize];
+            try!(stream.read_exact(&mut buf));
             // We could add a filter here, chat messages might be info!, position packets are debug!, etc...
             debug!("id={} length={} buf={:?} t2-t={}", PACKET_NAMES[id as usize], len, buf, t);
 

--- a/src/world.rs
+++ b/src/world.rs
@@ -224,7 +224,7 @@ impl World {
             let len = try!(<Var<i32> as Protocol>::proto_decode(&mut stream));
             let id = try!(<Var<i32> as Protocol>::proto_decode(&mut stream));
             let n_read = len - 1;
-            let mut buf = vec![0; n_read as usize];
+            let mut buf = vec![0u8; n_read as usize];
             try!(stream.read_exact(&mut buf));
             // We could add a filter here, chat messages might be info!, position packets are debug!, etc...
             debug!("id={} length={} buf={:?} t2-t={}", PACKET_NAMES[id as usize], len, buf, t);


### PR DESCRIPTION
Rust 1.6 stabilized [`std::io::Read::read_exact`](https://doc.rust-lang.org/nightly/std/io/trait.Read.html#method.read_exact), so we don't need our `util::ReadExactly` trait which basically did the same thing anymore. This pull request replaces every `read_exactly` call with the equivalent `read_exact` call, and removes the trait.
